### PR TITLE
Add lab management schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Bun
 node_modules
-bun.lockb
+bun.lock*
 dist
 .bun
 .DS_Store
@@ -16,6 +16,4 @@ build/
 
 # General
 .env
-
-# Python local development
-_.py
+slice-guard/backend/uploads/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Welcome to Slice Guard, a tool to help University 3D-print labs manage requests 
   - A modern, clean GUI for staff to approve or deny requests, with notifications for students when their requests are approved or denied.
 - Concurrent file management between multiple users.
 
+## File Storage
+
+Uploaded 3MF files are stored on the backend under `slice-guard/backend/uploads`.
+Files larger than 30MB are rejected. Each file is compressed using gzip to save
+space and its path is stored in the database. For large scale deployments an
+external storage service such as S3 is recommended, but for development local
+storage is sufficient.
+
 ### Planned Technologies
 
 - Docker for easy deployment and management.

--- a/slice-guard/backend/migrations/002_labs.sql
+++ b/slice-guard/backend/migrations/002_labs.sql
@@ -1,0 +1,26 @@
+CREATE SCHEMA IF NOT EXISTS lab;
+
+CREATE TABLE lab.labs (
+    id SERIAL PRIMARY KEY,
+    owner_id INTEGER NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT,
+    image_url TEXT,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE lab.roles (
+    id SERIAL PRIMARY KEY,
+    lab_id INTEGER NOT NULL REFERENCES lab.labs(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    permissions BIGINT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE lab.members (
+    lab_id INTEGER NOT NULL REFERENCES lab.labs(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    role_id INTEGER REFERENCES lab.roles(id) ON DELETE SET NULL,
+    joined_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (lab_id, user_id)
+);

--- a/slice-guard/backend/migrations/003_requests.sql
+++ b/slice-guard/backend/migrations/003_requests.sql
@@ -1,0 +1,23 @@
+CREATE TABLE lab.print_requests (
+    id SERIAL PRIMARY KEY,
+    lab_id INTEGER NOT NULL REFERENCES lab.labs(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    description TEXT,
+    file_path TEXT NOT NULL,
+    metadata JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE lab.request_tags (
+    id SERIAL PRIMARY KEY,
+    lab_id INTEGER NOT NULL REFERENCES lab.labs(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    is_default BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE lab.request_tag_assignments (
+    request_id INTEGER NOT NULL REFERENCES lab.print_requests(id) ON DELETE CASCADE,
+    tag_id INTEGER NOT NULL REFERENCES lab.request_tags(id) ON DELETE CASCADE,
+    PRIMARY KEY (request_id, tag_id)
+);

--- a/slice-guard/backend/src/db/lab.ts
+++ b/slice-guard/backend/src/db/lab.ts
@@ -1,0 +1,96 @@
+import type { Lab, LabRole, LabMember } from "@shared/db/lab";
+import type { SQL } from "bun";
+
+export interface LabRow extends Lab { }
+export interface LabRoleRow extends LabRole { }
+export interface LabMemberRow extends LabMember { }
+
+export async function createLab(
+    db: SQL,
+    ownerId: number,
+    name: string,
+    description: string | null = null,
+    imageUrl: string | null = null,
+): Promise<LabRow> {
+    const [row] = await db.query<LabRow>(
+        `INSERT INTO lab.labs (owner_id, name, description, image_url)
+           VALUES ($1, $2, $3, $4)
+        RETURNING id, owner_id, name, description, image_url, created_at`,
+        [ownerId, name, description, imageUrl]
+    );
+    return row;
+}
+
+export async function deleteLab(db: SQL, labId: number): Promise<void> {
+    await db.run(`DELETE FROM lab.labs WHERE id = $1`, [labId]);
+}
+
+export async function updateLab(
+    db: SQL,
+    labId: number,
+    name: string,
+    description: string | null,
+    imageUrl: string | null
+): Promise<LabRow> {
+    const [row] = await db.query<LabRow>(
+        `UPDATE lab.labs
+            SET name = $2, description = $3, image_url = $4
+          WHERE id = $1
+        RETURNING id, owner_id, name, description, image_url, created_at`,
+        [labId, name, description, imageUrl]
+    );
+    return row;
+}
+
+export async function createRole(
+    db: SQL,
+    labId: number,
+    name: string,
+    permissions: number
+): Promise<LabRoleRow> {
+    const [row] = await db.query<LabRoleRow>(
+        `INSERT INTO lab.roles (lab_id, name, permissions)
+           VALUES ($1, $2, $3)
+        RETURNING id, lab_id, name, permissions, created_at`,
+        [labId, name, permissions]
+    );
+    return row;
+}
+
+export async function addMember(
+    db: SQL,
+    labId: number,
+    userId: number,
+    roleId: number | null
+): Promise<LabMemberRow> {
+    const [row] = await db.query<LabMemberRow>(
+        `INSERT INTO lab.members (lab_id, user_id, role_id)
+           VALUES ($1, $2, $3)
+        RETURNING lab_id, user_id, role_id, joined_at`,
+        [labId, userId, roleId]
+    );
+    return row;
+}
+
+export async function removeMember(
+    db: SQL,
+    labId: number,
+    userId: number
+): Promise<void> {
+    await db.run(`DELETE FROM lab.members WHERE lab_id = $1 AND user_id = $2`, [labId, userId]);
+}
+
+export async function getMemberRolePermissions(
+    db: SQL,
+    labId: number,
+    userId: number
+): Promise<number | null> {
+    const [row] = await db.query<{ permissions: number }>(
+        `SELECT r.permissions
+           FROM lab.members m
+           JOIN lab.roles r ON m.role_id = r.id
+          WHERE m.lab_id = $1 AND m.user_id = $2`,
+        [labId, userId]
+    );
+    return row ? row.permissions : null;
+}

--- a/slice-guard/backend/src/db/request.ts
+++ b/slice-guard/backend/src/db/request.ts
@@ -1,0 +1,103 @@
+import type { PrintRequest, RequestTag } from "@shared/db/request";
+import type { SQL } from "bun";
+
+export interface PrintRequestRow extends PrintRequest { }
+export interface RequestTagRow extends RequestTag { }
+
+export async function createPrintRequest(
+    db: SQL,
+    labId: number,
+    userId: number,
+    filePath: string,
+    metadata: unknown,
+    description: string | null = null,
+): Promise<PrintRequestRow> {
+    const [row] = await db.query<PrintRequestRow>(
+        `INSERT INTO lab.print_requests (lab_id, user_id, file_path, metadata, description)
+           VALUES ($1, $2, $3, $4, $5)
+        RETURNING id, lab_id, user_id, file_path, metadata, description, created_at`,
+        [labId, userId, filePath, JSON.stringify(metadata), description]
+    );
+    return row;
+}
+
+export async function getUserPrintRequests(
+    db: SQL,
+    labId: number,
+    userId: number
+): Promise<PrintRequestRow[]> {
+    return db.query<PrintRequestRow>(
+        `SELECT id, lab_id, user_id, file_path, metadata, description, created_at
+           FROM lab.print_requests
+          WHERE lab_id = $1 AND user_id = $2`,
+        [labId, userId]
+    );
+}
+
+export async function createTag(
+    db: SQL,
+    labId: number,
+    name: string,
+    isDefault = false
+): Promise<RequestTagRow> {
+    const [row] = await db.query<RequestTagRow>(
+        `INSERT INTO lab.request_tags (lab_id, name, is_default)
+           VALUES ($1, $2, $3)
+        RETURNING id, lab_id, name, is_default, created_at`,
+        [labId, name, isDefault]
+    );
+    return row;
+}
+
+export async function setTagDefault(
+    db: SQL,
+    tagId: number,
+    isDefault: boolean
+): Promise<RequestTagRow> {
+    const [row] = await db.query<RequestTagRow>(
+        `UPDATE lab.request_tags
+            SET is_default = $2
+          WHERE id = $1
+        RETURNING id, lab_id, name, is_default, created_at`,
+        [tagId, isDefault]
+    );
+    return row;
+}
+
+export async function assignTag(
+    db: SQL,
+    requestId: number,
+    tagId: number
+): Promise<void> {
+    await db.run(
+        `INSERT INTO lab.request_tag_assignments (request_id, tag_id)
+           VALUES ($1, $2)
+        ON CONFLICT DO NOTHING`,
+        [requestId, tagId]
+    );
+}
+
+export async function unassignTag(
+    db: SQL,
+    requestId: number,
+    tagId: number
+): Promise<void> {
+    await db.run(
+        `DELETE FROM lab.request_tag_assignments
+          WHERE request_id = $1 AND tag_id = $2`,
+        [requestId, tagId]
+    );
+}
+
+export async function getTagsForRequest(
+    db: SQL,
+    requestId: number
+): Promise<RequestTagRow[]> {
+    return db.query<RequestTagRow>(
+        `SELECT t.id, t.lab_id, t.name, t.is_default, t.created_at
+           FROM lab.request_tag_assignments a
+           JOIN lab.request_tags t ON a.tag_id = t.id
+          WHERE a.request_id = $1`,
+        [requestId]
+    );
+}

--- a/slice-guard/backend/src/utils/storage.ts
+++ b/slice-guard/backend/src/utils/storage.ts
@@ -1,0 +1,22 @@
+import { promises as fs } from "fs";
+import { gzipSync } from "zlib";
+
+export const MAX_UPLOAD_SIZE = 30 * 1024 * 1024; // 30MB
+
+/**
+ * Saves a print request file to the uploads directory. The file is gzipped to
+ * reduce disk usage. Returns the path to the stored file.
+ */
+export async function saveRequestFile(labId: number, data: ArrayBuffer | Uint8Array): Promise<string> {
+    if (data.byteLength > MAX_UPLOAD_SIZE) {
+        throw new Error('File exceeds maximum allowed size');
+    }
+    const dir = `./slice-guard/backend/uploads/${labId}`;
+    await fs.mkdir(dir, { recursive: true });
+    const name = `${crypto.randomUUID()}.3mf.gz`;
+    const path = `${dir}/${name}`;
+    const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+    const compressed = gzipSync(bytes);
+    await fs.writeFile(path, compressed);
+    return path;
+}

--- a/slice-guard/backend/src/ws/handlers/index.ts
+++ b/slice-guard/backend/src/ws/handlers/index.ts
@@ -1,9 +1,11 @@
 import { OpCode, type OpCodePayload, type OpCodePayloadMap, type OpCodePayloadUnion, type OpCodeValue } from '@shared/ws/opcodes';
 import * as auth from "../handlers/auth";
+import * as requestHandlers from "../handlers/request";
 import type State from '../../utils/state';
 import type { Logger } from 'pino';
 import type { ServerWebSocket } from '..';
-import type { ErrorCode } from '@slice-guard/shared/ws/errors';
+import { ErrorCode } from '@slice-guard/shared/ws/errors';
+import { verifyJwt } from '../../utils/jwt';
 
 
 export class HandlerPayload<D> {
@@ -24,6 +26,23 @@ export type HandlerResponse = ErrorCode | OpCodePayloadUnion;
 
 export type Handler<D> = (payload: HandlerPayload<D>) => Promise<HandlerResponse>;
 
+export interface AuthenticatedPayload<D> extends HandlerPayload<D> {
+    userId: number;
+}
+
+export function withAuth<D>(handler: (payload: AuthenticatedPayload<D>) => Promise<HandlerResponse>): Handler<D & { token: string }> {
+    return async (payload: HandlerPayload<D & { token: string }>): Promise<HandlerResponse> => {
+        let userId: number;
+        try {
+            const decoded = verifyJwt(payload.data.d.token) as any;
+            userId = (decoded as any).id;
+        } catch {
+            return ErrorCode.UNAUTHORIZED;
+        }
+        return handler(Object.assign(payload, { userId }));
+    };
+}
+
 /**
  * Mapping of OpCode to handler function. Generic by default, so modules exporting this do not need to specify exactly
  * the OpCodes they cover.
@@ -42,8 +61,14 @@ export type HandlerMap<K extends OpCodeValue = OpCodeValue> = Partial<{
 type HandlerMapItems = OpCode.AUTH_LOGIN
     | OpCode.AUTH_REGISTER
     | OpCode.AUTH_REFRESH
-    | OpCode.AUTH_LOGOUT;
+    | OpCode.AUTH_LOGOUT
+    | OpCode.REQUEST_CREATE
+    | OpCode.REQUEST_LIST
+    | OpCode.TAG_CREATE
+    | OpCode.TAG_SET_DEFAULT
+    | OpCode.REQUEST_ASSIGN_TAG;
 
 export const handlers: HandlerMap<HandlerMapItems> = {
     ...auth.handlers,
+    ...requestHandlers.handlers,
 }

--- a/slice-guard/backend/src/ws/handlers/request.ts
+++ b/slice-guard/backend/src/ws/handlers/request.ts
@@ -1,0 +1,59 @@
+import { OpCode, type RequestCreatePayload, type RequestListPayload, type TagCreatePayload, type TagSetDefaultPayload, type RequestAssignTagPayload } from '@shared/ws/opcodes';
+import { withAuth, type AuthenticatedPayload, type HandlerMap } from '.';
+import { createPrintRequest, getUserPrintRequests, createTag, setTagDefault, assignTag, unassignTag } from '../../db/request';
+import { saveRequestFile } from '../../utils/storage';
+import { getMemberRolePermissions } from '../../db/lab';
+import { LabPermission } from '@shared/db/lab';
+import { ErrorCode } from '@slice-guard/shared/ws/errors';
+
+async function handleCreateRequest(payload: AuthenticatedPayload<RequestCreatePayload>) {
+    const { labId, file, metadata, description } = payload.data.d;
+    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    if (perms !== null && !(perms & LabPermission.CREATE_REQUEST)) {
+        return ErrorCode.UNAUTHORIZED;
+    }
+    const buffer = Buffer.from(file, 'base64');
+    const path = await saveRequestFile(labId, buffer);
+    const req = await createPrintRequest(payload.state.db, labId, payload.userId, path, metadata, description ?? null);
+    return { op: OpCode.REQUEST_CREATE, d: req };
+}
+
+async function handleListRequests(payload: AuthenticatedPayload<RequestListPayload>) {
+    const { labId } = payload.data.d;
+    const reqs = await getUserPrintRequests(payload.state.db, labId, payload.userId);
+    return { op: OpCode.REQUEST_LIST, d: reqs };
+}
+
+async function handleCreateTag(payload: AuthenticatedPayload<TagCreatePayload>) {
+    const { labId, name, isDefault } = payload.data.d;
+    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    if (perms === null || !(perms & LabPermission.MANAGE_ROLES)) {
+        return ErrorCode.UNAUTHORIZED;
+    }
+    const tag = await createTag(payload.state.db, labId, name, isDefault ?? false);
+    return { op: OpCode.TAG_CREATE, d: tag };
+}
+
+async function handleSetDefault(payload: AuthenticatedPayload<TagSetDefaultPayload>) {
+    const { tagId, isDefault } = payload.data.d;
+    const tag = await setTagDefault(payload.state.db, tagId, isDefault);
+    return { op: OpCode.TAG_SET_DEFAULT, d: tag };
+}
+
+async function handleAssignTag(payload: AuthenticatedPayload<RequestAssignTagPayload>) {
+    const { requestId, tagId, assign } = payload.data.d;
+    if (assign) {
+        await assignTag(payload.state.db, requestId, tagId);
+    } else {
+        await unassignTag(payload.state.db, requestId, tagId);
+    }
+    return { op: OpCode.REQUEST_ASSIGN_TAG, d: {} };
+}
+
+export const handlers: HandlerMap = {
+    [OpCode.REQUEST_CREATE]: withAuth(handleCreateRequest),
+    [OpCode.REQUEST_LIST]: withAuth(handleListRequests),
+    [OpCode.TAG_CREATE]: withAuth(handleCreateTag),
+    [OpCode.TAG_SET_DEFAULT]: withAuth(handleSetDefault),
+    [OpCode.REQUEST_ASSIGN_TAG]: withAuth(handleAssignTag),
+};

--- a/slice-guard/backend/tests/auth_middleware.test.ts
+++ b/slice-guard/backend/tests/auth_middleware.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import jwt from "jsonwebtoken";
+import { ErrorCode } from "@slice-guard/shared/ws/errors";
+
+process.env.JWT_SECRET = "test";
+const { withAuth } = await import("../src/ws/handlers");
+
+class DummyPayload {
+  ws = {} as any;
+  state = {} as any;
+  logger = console as any;
+}
+
+test("withAuth denies invalid token", async () => {
+  const handler = withAuth(async () => ({ op: 0 as any, d: {} }));
+  const result = await handler({ ...new DummyPayload(), data: { op: 0 as any, d: { token: "bad" } } });
+  expect(result).toBe(ErrorCode.UNAUTHORIZED);
+});
+
+test("withAuth passes userId", async () => {
+  const token = jwt.sign({ id: 42 }, "test", { expiresIn: "1h" });
+  let id: number | null = null;
+  const handler = withAuth(async (p) => { id = p.userId; return { op: 0 as any, d: {} }; });
+  await handler({ ...new DummyPayload(), data: { op: 0 as any, d: { token } } });
+  expect(id).toBe(42);
+});

--- a/slice-guard/backend/tests/lab.test.ts
+++ b/slice-guard/backend/tests/lab.test.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "bun:test";
+import {
+  createLab,
+  deleteLab,
+  updateLab,
+  createRole,
+  addMember,
+  removeMember,
+  getMemberRolePermissions,
+  type LabRow,
+  type LabRoleRow,
+  type LabMemberRow,
+} from "../src/db/lab";
+
+class MockDB {
+  public lastQuery: string | null = null;
+  public lastParams: any[] | null = null;
+  private result: any[];
+
+  constructor(result: any[] = []) {
+    this.result = result;
+  }
+
+  async query<T>(sql: string, params: any[]): Promise<T[]> {
+    this.lastQuery = sql;
+    this.lastParams = params;
+    return this.result as T[];
+  }
+
+  async run(sql: string, params: any[]): Promise<void> {
+    this.lastQuery = sql;
+    this.lastParams = params;
+  }
+}
+
+function normalize(sql: string | null) {
+  return sql ? sql.replace(/\s+/g, " ").trim() : "";
+}
+
+function sampleLab(): LabRow {
+  return {
+    id: 1,
+    owner_id: 2,
+    name: "Test Lab",
+    description: "Desc",
+    image_url: "img",
+    created_at: new Date(),
+  };
+}
+
+function sampleRole(): LabRoleRow {
+  return {
+    id: 1,
+    lab_id: 1,
+    name: "Role",
+    permissions: 1,
+    created_at: new Date(),
+  };
+}
+
+function sampleMember(): LabMemberRow {
+  return {
+    lab_id: 1,
+    user_id: 2,
+    role_id: 1,
+    joined_at: new Date(),
+  };
+}
+
+test("createLab inserts expected values", async () => {
+  const lab = sampleLab();
+  const db = new MockDB([lab]);
+  const result = await createLab(db as any, lab.owner_id, lab.name, lab.description!, lab.image_url!);
+  expect(normalize(db.lastQuery)).toBe(
+    "INSERT INTO lab.labs (owner_id, name, description, image_url) VALUES ($1, $2, $3, $4) RETURNING id, owner_id, name, description, image_url, created_at"
+  );
+  expect(db.lastParams).toEqual([lab.owner_id, lab.name, lab.description, lab.image_url]);
+  expect(result).toEqual(lab);
+});
+
+test("deleteLab deletes by id", async () => {
+  const db = new MockDB();
+  await deleteLab(db as any, 1);
+  expect(normalize(db.lastQuery)).toBe("DELETE FROM lab.labs WHERE id = $1");
+  expect(db.lastParams).toEqual([1]);
+});
+
+test("updateLab updates fields", async () => {
+  const lab = sampleLab();
+  const db = new MockDB([lab]);
+  const result = await updateLab(db as any, lab.id, lab.name, lab.description!, lab.image_url!);
+  expect(normalize(db.lastQuery)).toBe(
+    "UPDATE lab.labs SET name = $2, description = $3, image_url = $4 WHERE id = $1 RETURNING id, owner_id, name, description, image_url, created_at"
+  );
+  expect(db.lastParams).toEqual([lab.id, lab.name, lab.description, lab.image_url]);
+  expect(result).toEqual(lab);
+});
+
+test("createRole inserts expected values", async () => {
+  const role = sampleRole();
+  const db = new MockDB([role]);
+  const result = await createRole(db as any, role.lab_id, role.name, role.permissions as number);
+  expect(normalize(db.lastQuery)).toBe(
+    "INSERT INTO lab.roles (lab_id, name, permissions) VALUES ($1, $2, $3) RETURNING id, lab_id, name, permissions, created_at"
+  );
+  expect(db.lastParams).toEqual([role.lab_id, role.name, role.permissions]);
+  expect(result).toEqual(role);
+});
+
+test("addMember inserts expected values", async () => {
+  const m = sampleMember();
+  const db = new MockDB([m]);
+  const result = await addMember(db as any, m.lab_id, m.user_id, m.role_id!);
+  expect(normalize(db.lastQuery)).toBe(
+    "INSERT INTO lab.members (lab_id, user_id, role_id) VALUES ($1, $2, $3) RETURNING lab_id, user_id, role_id, joined_at"
+  );
+  expect(db.lastParams).toEqual([m.lab_id, m.user_id, m.role_id]);
+  expect(result).toEqual(m);
+});
+
+test("removeMember deletes by composite id", async () => {
+  const db = new MockDB();
+  await removeMember(db as any, 1, 2);
+  expect(normalize(db.lastQuery)).toBe(
+    "DELETE FROM lab.members WHERE lab_id = $1 AND user_id = $2"
+  );
+  expect(db.lastParams).toEqual([1, 2]);
+});
+
+test("getMemberRolePermissions selects join", async () => {
+  const db = new MockDB([{ permissions: 8 }]);
+  const result = await getMemberRolePermissions(db as any, 1, 2);
+  expect(normalize(db.lastQuery)).toBe(
+    "SELECT r.permissions FROM lab.members m JOIN lab.roles r ON m.role_id = r.id WHERE m.lab_id = $1 AND m.user_id = $2"
+  );
+  expect(db.lastParams).toEqual([1, 2]);
+  expect(result).toEqual(8);
+});

--- a/slice-guard/backend/tests/request.test.ts
+++ b/slice-guard/backend/tests/request.test.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "bun:test";
+import {
+  createPrintRequest,
+  getUserPrintRequests,
+  createTag,
+  setTagDefault,
+  assignTag,
+  unassignTag,
+  getTagsForRequest,
+  type PrintRequestRow,
+  type RequestTagRow,
+} from "../src/db/request";
+
+class MockDB {
+  public lastQuery: string | null = null;
+  public lastParams: any[] | null = null;
+  private result: any[];
+
+  constructor(result: any[] = []) {
+    this.result = result;
+  }
+
+  async query<T>(sql: string, params: any[]): Promise<T[]> {
+    this.lastQuery = sql;
+    this.lastParams = params;
+    return this.result as T[];
+  }
+
+  async run(sql: string, params: any[]): Promise<void> {
+    this.lastQuery = sql;
+    this.lastParams = params;
+  }
+}
+
+function normalize(sql: string | null) {
+  return sql ? sql.replace(/\s+/g, " ").trim() : "";
+}
+
+function sampleRequest(): PrintRequestRow {
+  return {
+    id: 1,
+    lab_id: 1,
+    user_id: 2,
+    file_path: "path",
+    metadata: { a: 1 },
+    description: "desc",
+    created_at: new Date(),
+  };
+}
+
+function sampleTag(): RequestTagRow {
+  return {
+    id: 1,
+    lab_id: 1,
+    name: "Pending",
+    is_default: false,
+    created_at: new Date(),
+  };
+}
+
+test("createPrintRequest inserts expected values", async () => {
+  const req = sampleRequest();
+  const db = new MockDB([req]);
+  const result = await createPrintRequest(db as any, req.lab_id, req.user_id, req.file_path, req.metadata, req.description!);
+  expect(normalize(db.lastQuery)).toBe(
+    "INSERT INTO lab.print_requests (lab_id, user_id, file_path, metadata, description) VALUES ($1, $2, $3, $4, $5) RETURNING id, lab_id, user_id, file_path, metadata, description, created_at"
+  );
+  expect(db.lastParams).toEqual([req.lab_id, req.user_id, req.file_path, JSON.stringify(req.metadata), req.description]);
+  expect(result).toEqual(req);
+});
+
+test("getUserPrintRequests selects expected", async () => {
+  const req = sampleRequest();
+  const db = new MockDB([req]);
+  const result = await getUserPrintRequests(db as any, req.lab_id, req.user_id);
+  expect(normalize(db.lastQuery)).toBe(
+    "SELECT id, lab_id, user_id, file_path, metadata, description, created_at FROM lab.print_requests WHERE lab_id = $1 AND user_id = $2"
+  );
+  expect(db.lastParams).toEqual([req.lab_id, req.user_id]);
+  expect(result).toEqual([req]);
+});
+
+test("createTag inserts expected values", async () => {
+  const tag = sampleTag();
+  const db = new MockDB([tag]);
+  const result = await createTag(db as any, tag.lab_id, tag.name, tag.is_default);
+  expect(normalize(db.lastQuery)).toBe(
+    "INSERT INTO lab.request_tags (lab_id, name, is_default) VALUES ($1, $2, $3) RETURNING id, lab_id, name, is_default, created_at"
+  );
+  expect(db.lastParams).toEqual([tag.lab_id, tag.name, tag.is_default]);
+  expect(result).toEqual(tag);
+});
+
+test("setTagDefault updates flag", async () => {
+  const tag = sampleTag();
+  const db = new MockDB([tag]);
+  const result = await setTagDefault(db as any, tag.id, true);
+  expect(normalize(db.lastQuery)).toBe(
+    "UPDATE lab.request_tags SET is_default = $2 WHERE id = $1 RETURNING id, lab_id, name, is_default, created_at"
+  );
+  expect(db.lastParams).toEqual([tag.id, true]);
+  expect(result).toEqual(tag);
+});
+
+test("assignTag inserts mapping", async () => {
+  const db = new MockDB();
+  await assignTag(db as any, 1, 2);
+  expect(normalize(db.lastQuery)).toBe(
+    "INSERT INTO lab.request_tag_assignments (request_id, tag_id) VALUES ($1, $2) ON CONFLICT DO NOTHING"
+  );
+  expect(db.lastParams).toEqual([1, 2]);
+});
+
+test("unassignTag deletes mapping", async () => {
+  const db = new MockDB();
+  await unassignTag(db as any, 1, 2);
+  expect(normalize(db.lastQuery)).toBe(
+    "DELETE FROM lab.request_tag_assignments WHERE request_id = $1 AND tag_id = $2"
+  );
+  expect(db.lastParams).toEqual([1, 2]);
+});
+
+test("getTagsForRequest selects join", async () => {
+  const tag = sampleTag();
+  const db = new MockDB([tag]);
+  const result = await getTagsForRequest(db as any, 1);
+  expect(normalize(db.lastQuery)).toBe(
+    "SELECT t.id, t.lab_id, t.name, t.is_default, t.created_at FROM lab.request_tag_assignments a JOIN lab.request_tags t ON a.tag_id = t.id WHERE a.request_id = $1"
+  );
+  expect(db.lastParams).toEqual([1]);
+  expect(result).toEqual([tag]);
+});

--- a/slice-guard/backend/tests/storage.test.ts
+++ b/slice-guard/backend/tests/storage.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import { saveRequestFile, MAX_UPLOAD_SIZE } from "../src/utils/storage";
+import { existsSync, rmSync, readFileSync } from "fs";
+
+const dir = "slice-guard/backend/uploads/1";
+
+function cleanup() {
+  if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+}
+
+cleanup();
+
+const sample = new TextEncoder().encode("hello world");
+
+test("saveRequestFile stores gzipped file", async () => {
+  const path = await saveRequestFile(1, sample);
+  expect(existsSync(path)).toBe(true);
+  const contents = readFileSync(path);
+  expect(contents.length).toBeGreaterThan(0);
+});
+
+test("saveRequestFile rejects large files", async () => {
+  const big = new Uint8Array(MAX_UPLOAD_SIZE + 1);
+  await expect(saveRequestFile(1, big)).rejects.toThrow();
+});
+
+cleanup();

--- a/slice-guard/shared/db/lab.ts
+++ b/slice-guard/shared/db/lab.ts
@@ -1,0 +1,31 @@
+export interface Lab {
+    id: number;
+    owner_id: number;
+    name: string;
+    description?: string | null;
+    image_url?: string | null;
+    created_at: Date;
+}
+
+export interface LabRole {
+    id: number;
+    lab_id: number;
+    name: string;
+    permissions: bigint | number;
+    created_at: Date;
+}
+
+export interface LabMember {
+    lab_id: number;
+    user_id: number;
+    role_id?: number | null;
+    joined_at: Date;
+}
+
+export enum LabPermission {
+    EDIT_LAB = 1 << 0,
+    MANAGE_ROLES = 1 << 1,
+    REMOVE_USER = 1 << 2,
+    DELETE_LAB = 1 << 3,
+    CREATE_REQUEST = 1 << 4,
+}

--- a/slice-guard/shared/db/request.ts
+++ b/slice-guard/shared/db/request.ts
@@ -1,0 +1,17 @@
+export interface PrintRequest {
+    id: number;
+    lab_id: number;
+    user_id: number;
+    description?: string | null;
+    file_path: string;
+    metadata: unknown;
+    created_at: Date;
+}
+
+export interface RequestTag {
+    id: number;
+    lab_id: number;
+    name: string;
+    is_default: boolean;
+    created_at: Date;
+}

--- a/slice-guard/shared/ws/errors.ts
+++ b/slice-guard/shared/ws/errors.ts
@@ -8,6 +8,7 @@ export enum ErrorCode {
     INTERNAL_ERROR = "INTERNAL_ERROR",
     NOT_FOUND = "NOT_FOUND",
     UNIMPLEMENTED = "UNIMPLEMENTED",
+    UNAUTHORIZED = "UNAUTHORIZED",
 }
 
 export type ErrorCodeType = keyof typeof ErrorCode;
@@ -19,6 +20,7 @@ export const ErrorCodeMapping: Record<ErrorCodeValue, ErrorCodeMappingValue> = {
     [ErrorCode.INTERNAL_ERROR]: 500,
     [ErrorCode.NOT_FOUND]: 404,
     [ErrorCode.UNIMPLEMENTED]: 501,
+    [ErrorCode.UNAUTHORIZED]: 401,
 }
 
 export function toErrorCodeValue(code: ErrorCodeValue): ErrorCodeMappingValue {

--- a/slice-guard/shared/ws/opcodes.ts
+++ b/slice-guard/shared/ws/opcodes.ts
@@ -10,6 +10,11 @@ export enum OpCode {
     AUTH_REFRESH_SUCCESS = 5,
     AUTH_LOGOUT = 6,
     ERROR = 7,
+    REQUEST_CREATE = 8,
+    REQUEST_LIST = 9,
+    TAG_CREATE = 10,
+    TAG_SET_DEFAULT = 11,
+    REQUEST_ASSIGN_TAG = 12,
 }
 
 // Generic type for WebSocket payloads
@@ -94,3 +99,9 @@ export type AuthLogoutPayload = OpCodePayload<OpCode.AUTH_LOGOUT> & { d: { refre
  */
 
 export type ErrorPayload<E extends ErrorCodeType> = OpCodePayload<OpCode.ERROR> & { d: { error: E, response: ErrorCodeMappingValue } };
+
+export type RequestCreatePayload = OpCodePayload<OpCode.REQUEST_CREATE> & { d: { labId: number; file: string; metadata: any; description?: string; token: string } };
+export type RequestListPayload = OpCodePayload<OpCode.REQUEST_LIST> & { d: { labId: number; token: string } };
+export type TagCreatePayload = OpCodePayload<OpCode.TAG_CREATE> & { d: { labId: number; name: string; isDefault?: boolean; token: string } };
+export type TagSetDefaultPayload = OpCodePayload<OpCode.TAG_SET_DEFAULT> & { d: { tagId: number; isDefault: boolean; token: string } };
+export type RequestAssignTagPayload = OpCodePayload<OpCode.REQUEST_ASSIGN_TAG> & { d: { requestId: number; tagId: number; assign: boolean; token: string } };


### PR DESCRIPTION
## Summary
- fix gitignore to ignore Bun lock file
- add permission flag for creating print requests
- add UNAUTHORIZED error code and new WebSocket opcodes
- create database tables for print requests and tags
- implement utilities and handlers for managing requests and tags
- add authentication middleware and unit tests
- store uploaded 3MF files on the server using gzip
- update request creation to upload base64 encoded files
- document upload storage policy

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_685c4047a67c83208a41a588b3840dce