### PR TITLE
Remove generics from DB SQL queries

### DIFF
--- a/slice-guard/backend/WS_ROUTES.md
+++ b/slice-guard/backend/WS_ROUTES.md
@@ -1,0 +1,23 @@
+# WebSocket Routes
+
+This document lists all websocket opcodes exposed by the backend along with a short description of the request payload and the response returned. Every message is a JSON object with the structure `{ op: number, d: any }`.
+
+| OpCode | Direction | Payload (`d`) | Description |
+| ------ | --------- | ------------- | ----------- |
+| `AUTH_LOGIN` | client -> server | `{ email, password }` | Log in a user. Returns `AUTH_SUCCESS` or `AUTH_FAILURE`. |
+| `AUTH_REGISTER` | client -> server | `{ email, password, name }` | Register a new user. Returns `AUTH_SUCCESS` or `AUTH_FAILURE`. |
+| `AUTH_REFRESH` | client -> server | `{ refreshToken }` | Refresh an access token. Returns `AUTH_REFRESH_SUCCESS` or `AUTH_FAILURE`. |
+| `AUTH_LOGOUT` | client -> server | `{ refreshToken }` | Invalidate a refresh token. |
+| `REQUEST_CREATE` | client -> server | `{ labId, file, metadata, description?, token }` | Upload a print request. Returns created request. |
+| `REQUEST_LIST` | client -> server | `{ labId, token }` | List user requests for a lab. |
+| `TAG_CREATE` | client -> server | `{ labId, name, isDefault?, token }` | Create a new request tag. |
+| `TAG_SET_DEFAULT` | client -> server | `{ tagId, isDefault, token }` | Toggle default status on a tag. |
+| `REQUEST_ASSIGN_TAG` | client -> server | `{ requestId, tagId, assign, token }` | Assign or remove a tag from a request. |
+| `LAB_CREATE` | client -> server | `{ name, description?, imageUrl?, token }` | Create a new lab owned by the user. |
+| `LAB_UPDATE` | client -> server | `{ labId, name, description?, imageUrl?, token }` | Update a lab's fields. Requires `EDIT_LAB` permission. |
+| `LAB_DELETE` | client -> server | `{ labId, token }` | Delete a lab. Requires `DELETE_LAB` permission. |
+| `ROLE_CREATE` | client -> server | `{ labId, name, permissions, token }` | Create a role in a lab. Requires `MANAGE_ROLES`. |
+| `MEMBER_ADD` | client -> server | `{ labId, userId, roleId, token }` | Add a member to a lab. Requires `MANAGE_ROLES`. |
+| `MEMBER_REMOVE` | client -> server | `{ labId, userId, token }` | Remove a user from a lab. Requires `REMOVE_USER`. |
+
+Responses use the same opcode as the request unless otherwise noted. Errors are reported with opcode `ERROR` and follow `{ code, message }`.

--- a/slice-guard/backend/src/db/lab.ts
+++ b/slice-guard/backend/src/db/lab.ts
@@ -12,17 +12,19 @@ export async function createLab(
     description: string | null = null,
     imageUrl: string | null = null,
 ): Promise<LabRow> {
-    const [row] = await db.query<LabRow>(
-        `INSERT INTO lab.labs (owner_id, name, description, image_url)
-           VALUES ($1, $2, $3, $4)
-        RETURNING id, owner_id, name, description, image_url, created_at`,
-        [ownerId, name, description, imageUrl]
-    );
-    return row;
+    const rows: LabRow[] = await db`
+        INSERT INTO lab.labs (owner_id, name, description, image_url)
+             VALUES (${ownerId}, ${name}, ${description}, ${imageUrl})
+        RETURNING id, owner_id, name, description, image_url, created_at
+    `;
+    return rows[0];
 }
 
 export async function deleteLab(db: SQL, labId: number): Promise<void> {
-    await db.run(`DELETE FROM lab.labs WHERE id = $1`, [labId]);
+    await db`
+        DELETE FROM lab.labs
+         WHERE id = ${labId}
+    `;
 }
 
 export async function updateLab(
@@ -32,14 +34,13 @@ export async function updateLab(
     description: string | null,
     imageUrl: string | null
 ): Promise<LabRow> {
-    const [row] = await db.query<LabRow>(
-        `UPDATE lab.labs
-            SET name = $2, description = $3, image_url = $4
-          WHERE id = $1
-        RETURNING id, owner_id, name, description, image_url, created_at`,
-        [labId, name, description, imageUrl]
-    );
-    return row;
+    const rows: LabRow[] = await db`
+        UPDATE lab.labs
+           SET name = ${name}, description = ${description}, image_url = ${imageUrl}
+         WHERE id = ${labId}
+        RETURNING id, owner_id, name, description, image_url, created_at
+    `;
+    return rows[0];
 }
 
 export async function createRole(
@@ -48,13 +49,12 @@ export async function createRole(
     name: string,
     permissions: number
 ): Promise<LabRoleRow> {
-    const [row] = await db.query<LabRoleRow>(
-        `INSERT INTO lab.roles (lab_id, name, permissions)
-           VALUES ($1, $2, $3)
-        RETURNING id, lab_id, name, permissions, created_at`,
-        [labId, name, permissions]
-    );
-    return row;
+    const rows: LabRoleRow[] = await db`
+        INSERT INTO lab.roles (lab_id, name, permissions)
+             VALUES (${labId}, ${name}, ${permissions})
+        RETURNING id, lab_id, name, permissions, created_at
+    `;
+    return rows[0];
 }
 
 export async function addMember(
@@ -63,13 +63,12 @@ export async function addMember(
     userId: number,
     roleId: number | null
 ): Promise<LabMemberRow> {
-    const [row] = await db.query<LabMemberRow>(
-        `INSERT INTO lab.members (lab_id, user_id, role_id)
-           VALUES ($1, $2, $3)
-        RETURNING lab_id, user_id, role_id, joined_at`,
-        [labId, userId, roleId]
-    );
-    return row;
+    const rows: LabMemberRow[] = await db`
+        INSERT INTO lab.members (lab_id, user_id, role_id)
+             VALUES (${labId}, ${userId}, ${roleId})
+        RETURNING lab_id, user_id, role_id, joined_at
+    `;
+    return rows[0];
 }
 
 export async function removeMember(
@@ -77,7 +76,10 @@ export async function removeMember(
     labId: number,
     userId: number
 ): Promise<void> {
-    await db.run(`DELETE FROM lab.members WHERE lab_id = $1 AND user_id = $2`, [labId, userId]);
+    await db`
+        DELETE FROM lab.members
+         WHERE lab_id = ${labId} AND user_id = ${userId}
+    `;
 }
 
 export async function getMemberRolePermissions(
@@ -85,12 +87,12 @@ export async function getMemberRolePermissions(
     labId: number,
     userId: number
 ): Promise<number | null> {
-    const [row] = await db.query<{ permissions: number }>(
-        `SELECT r.permissions
-           FROM lab.members m
-           JOIN lab.roles r ON m.role_id = r.id
-          WHERE m.lab_id = $1 AND m.user_id = $2`,
-        [labId, userId]
-    );
+    const rows: { permissions: number }[] = await db`
+        SELECT r.permissions
+          FROM lab.members m
+          JOIN lab.roles r ON m.role_id = r.id
+         WHERE m.lab_id = ${labId} AND m.user_id = ${userId}
+    `;
+    const [row] = rows;
     return row ? row.permissions : null;
 }

--- a/slice-guard/backend/src/db/request.ts
+++ b/slice-guard/backend/src/db/request.ts
@@ -12,13 +12,12 @@ export async function createPrintRequest(
     metadata: unknown,
     description: string | null = null,
 ): Promise<PrintRequestRow> {
-    const [row] = await db.query<PrintRequestRow>(
-        `INSERT INTO lab.print_requests (lab_id, user_id, file_path, metadata, description)
-           VALUES ($1, $2, $3, $4, $5)
-        RETURNING id, lab_id, user_id, file_path, metadata, description, created_at`,
-        [labId, userId, filePath, JSON.stringify(metadata), description]
-    );
-    return row;
+    const rows: PrintRequestRow[] = await db`
+        INSERT INTO lab.print_requests (lab_id, user_id, file_path, metadata, description)
+             VALUES (${labId}, ${userId}, ${filePath}, ${JSON.stringify(metadata)}, ${description})
+        RETURNING id, lab_id, user_id, file_path, metadata, description, created_at
+    `;
+    return rows[0];
 }
 
 export async function getUserPrintRequests(
@@ -26,12 +25,12 @@ export async function getUserPrintRequests(
     labId: number,
     userId: number
 ): Promise<PrintRequestRow[]> {
-    return db.query<PrintRequestRow>(
-        `SELECT id, lab_id, user_id, file_path, metadata, description, created_at
-           FROM lab.print_requests
-          WHERE lab_id = $1 AND user_id = $2`,
-        [labId, userId]
-    );
+    const rows: PrintRequestRow[] = await db`
+        SELECT id, lab_id, user_id, file_path, metadata, description, created_at
+          FROM lab.print_requests
+         WHERE lab_id = ${labId} AND user_id = ${userId}
+    `;
+    return rows;
 }
 
 export async function createTag(
@@ -40,13 +39,12 @@ export async function createTag(
     name: string,
     isDefault = false
 ): Promise<RequestTagRow> {
-    const [row] = await db.query<RequestTagRow>(
-        `INSERT INTO lab.request_tags (lab_id, name, is_default)
-           VALUES ($1, $2, $3)
-        RETURNING id, lab_id, name, is_default, created_at`,
-        [labId, name, isDefault]
-    );
-    return row;
+    const rows: RequestTagRow[] = await db`
+        INSERT INTO lab.request_tags (lab_id, name, is_default)
+             VALUES (${labId}, ${name}, ${isDefault})
+        RETURNING id, lab_id, name, is_default, created_at
+    `;
+    return rows[0];
 }
 
 export async function setTagDefault(
@@ -54,14 +52,13 @@ export async function setTagDefault(
     tagId: number,
     isDefault: boolean
 ): Promise<RequestTagRow> {
-    const [row] = await db.query<RequestTagRow>(
-        `UPDATE lab.request_tags
-            SET is_default = $2
-          WHERE id = $1
-        RETURNING id, lab_id, name, is_default, created_at`,
-        [tagId, isDefault]
-    );
-    return row;
+    const rows: RequestTagRow[] = await db`
+        UPDATE lab.request_tags
+           SET is_default = ${isDefault}
+         WHERE id = ${tagId}
+        RETURNING id, lab_id, name, is_default, created_at
+    `;
+    return rows[0];
 }
 
 export async function assignTag(
@@ -69,12 +66,11 @@ export async function assignTag(
     requestId: number,
     tagId: number
 ): Promise<void> {
-    await db.run(
-        `INSERT INTO lab.request_tag_assignments (request_id, tag_id)
-           VALUES ($1, $2)
-        ON CONFLICT DO NOTHING`,
-        [requestId, tagId]
-    );
+    await db`
+        INSERT INTO lab.request_tag_assignments (request_id, tag_id)
+             VALUES (${requestId}, ${tagId})
+        ON CONFLICT DO NOTHING
+    `;
 }
 
 export async function unassignTag(
@@ -82,22 +78,21 @@ export async function unassignTag(
     requestId: number,
     tagId: number
 ): Promise<void> {
-    await db.run(
-        `DELETE FROM lab.request_tag_assignments
-          WHERE request_id = $1 AND tag_id = $2`,
-        [requestId, tagId]
-    );
+    await db`
+        DELETE FROM lab.request_tag_assignments
+         WHERE request_id = ${requestId} AND tag_id = ${tagId}
+    `;
 }
 
 export async function getTagsForRequest(
     db: SQL,
     requestId: number
 ): Promise<RequestTagRow[]> {
-    return db.query<RequestTagRow>(
-        `SELECT t.id, t.lab_id, t.name, t.is_default, t.created_at
-           FROM lab.request_tag_assignments a
-           JOIN lab.request_tags t ON a.tag_id = t.id
-          WHERE a.request_id = $1`,
-        [requestId]
-    );
+    const rows: RequestTagRow[] = await db`
+        SELECT t.id, t.lab_id, t.name, t.is_default, t.created_at
+          FROM lab.request_tag_assignments a
+          JOIN lab.request_tags t ON a.tag_id = t.id
+         WHERE a.request_id = ${requestId}
+    `;
+    return rows;
 }

--- a/slice-guard/backend/src/db/user.ts
+++ b/slice-guard/backend/src/db/user.ts
@@ -23,65 +23,69 @@ export interface RefreshTokenRow {
 
 /** Fetch a user by their e-mail address. */
 export async function findUserByEmail(db: SQL, email: string): Promise<UserWithPassword | null> {
-    const [row] = await db.query<UserWithPassword>(
-        `SELECT id, email, name, created_at, password_hash
-           FROM auth.users
-          WHERE email = $1`,
-        [email]
-    );
+    const rows: UserWithPassword[] = await db`
+        SELECT id, email, name, created_at, password_hash
+          FROM auth.users
+         WHERE email = ${email}
+    `;
+    const [row] = rows;
     return row ?? null;
 }
 
 /** Fetch a user by their database id. */
 export async function findUserById(db: SQL, id: number): Promise<UserWithPassword | null> {
-    const [row] = await db.query<UserWithPassword>(
-        `SELECT id, email, name, created_at, password_hash
-           FROM auth.users
-          WHERE id = $1`,
-        [id]
-    );
+    const rows: UserWithPassword[] = await db`
+        SELECT id, email, name, created_at, password_hash
+          FROM auth.users
+         WHERE id = ${id}
+    `;
+    const [row] = rows;
     return row ?? null;
 }
 
 /** Create a new user in the database. */
 export async function createUser(db: SQL, email: string, passwordHash: string, name: string): Promise<UserWithPassword> {
-    const [row] = await db.query<UserWithPassword>(
-        `INSERT INTO auth.users (email, password_hash, name)
-           VALUES ($1, $2, $3)
-        RETURNING id, email, name, created_at, password_hash`,
-        [email, passwordHash, name]
-    );
-    return row;
+    const rows: UserWithPassword[] = await db`
+        INSERT INTO auth.users (email, password_hash, name)
+             VALUES (${email}, ${passwordHash}, ${name})
+        RETURNING id, email, name, created_at, password_hash
+    `;
+    return rows[0];
 }
 
 /** Store a refresh token for a user. */
 export async function insertRefreshToken(db: SQL, userId: number, token: string, expiresAt: Date): Promise<RefreshTokenRow> {
-    const [row] = await db.query<RefreshTokenRow>(
-        `INSERT INTO auth.refresh_tokens (user_id, token, expires_at)
-           VALUES ($1, $2, $3)
-        RETURNING id, user_id, token, created_at, expires_at`,
-        [userId, token, expiresAt]
-    );
-    return row;
+    const rows: RefreshTokenRow[] = await db`
+        INSERT INTO auth.refresh_tokens (user_id, token, expires_at)
+             VALUES (${userId}, ${token}, ${expiresAt})
+        RETURNING id, user_id, token, created_at, expires_at
+    `;
+    return rows[0];
 }
 
 /** Retrieve a refresh token record if it exists. */
 export async function getRefreshToken(db: SQL, token: string): Promise<RefreshTokenRow | null> {
-    const [row] = await db.query<RefreshTokenRow>(
-        `SELECT id, user_id, token, created_at, expires_at
-           FROM auth.refresh_tokens
-          WHERE token = $1`,
-        [token]
-    );
+    const rows: RefreshTokenRow[] = await db`
+        SELECT id, user_id, token, created_at, expires_at
+          FROM auth.refresh_tokens
+         WHERE token = ${token}
+    `;
+    const [row] = rows;
     return row ?? null;
 }
 
 /** Delete a specific refresh token. */
 export async function deleteRefreshToken(db: SQL, token: string): Promise<void> {
-    await db.run(`DELETE FROM auth.refresh_tokens WHERE token = $1`, [token]);
+    await db`
+        DELETE FROM auth.refresh_tokens
+         WHERE token = ${token}
+    `;
 }
 
 /** Remove all refresh tokens belonging to a user. */
 export async function deleteTokensForUser(db: SQL, userId: number): Promise<void> {
-    await db.run(`DELETE FROM auth.refresh_tokens WHERE user_id = $1`, [userId]);
+    await db`
+        DELETE FROM auth.refresh_tokens
+         WHERE user_id = ${userId}
+    `;
 }

--- a/slice-guard/backend/src/ws/handlers/auth.ts
+++ b/slice-guard/backend/src/ws/handlers/auth.ts
@@ -3,9 +3,15 @@
  * Defines handlers for login, register, refresh, and logout operations.
  */
 
-import { OpCode, type AuthLoginPayload, type AuthLogoutPayload, type AuthRefreshPayload, type AuthSuccessPayload, type AuthFailurePayload } from "@shared/ws/opcodes"
-import type { HandlerMap, HandlerPayload } from "."
-import { ErrorCode } from "@slice-guard/shared/ws/errors";
+import {
+    OpCode,
+    type AuthLoginPayload,
+    type AuthLogoutPayload,
+    type AuthRefreshPayload,
+    type AuthSuccessPayload,
+    type AuthFailurePayload,
+} from "@shared/ws/opcodes";
+import type { HandlerMap, HandlerPayload } from ".";
 import { hashPassword, verifyPassword } from "../../utils/hash";
 import { signJwt } from "../../utils/jwt";
 import { generateRefreshToken } from "../../utils/refresh";
@@ -16,8 +22,7 @@ import {
     insertRefreshToken,
     getRefreshToken,
     deleteRefreshToken,
-    deleteTokensForUser,
-    type UserWithPassword
+    type UserWithPassword,
 } from "../../db/user";
 
 export const handlers: HandlerMap = {
@@ -27,9 +32,16 @@ export const handlers: HandlerMap = {
     [OpCode.AUTH_LOGOUT]: handleAuthLogout,
 };
 
-function buildSuccess(user: UserWithPassword, access: string, refresh: string): AuthSuccessPayload {
+function buildSuccess(
+    user: UserWithPassword,
+    access: string,
+    refresh: string
+): AuthSuccessPayload {
     const { password_hash, ...publicUser } = user;
-    return { op: OpCode.AUTH_SUCCESS, d: { accessToken: access, refreshToken: refresh, user: publicUser } };
+    return {
+        op: OpCode.AUTH_SUCCESS,
+        d: { accessToken: access, refreshToken: refresh, user: publicUser },
+    };
 }
 
 function buildFailure(reason: string): AuthFailurePayload {
@@ -52,7 +64,12 @@ async function handleAuthLogin(payload: HandlerPayload<AuthLoginPayload>) {
     const accessToken = signJwt({ id: user.id });
     const refreshToken = generateRefreshToken(user.id.toString());
 
-    await insertRefreshToken(payload.state.db, user.id, refreshToken, new Date(Date.now() + 7 * 24 * 60 * 60 * 1000));
+    await insertRefreshToken(
+        payload.state.db,
+        user.id,
+        refreshToken,
+        new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+    );
 
     return buildSuccess(user, accessToken, refreshToken);
 }
@@ -70,7 +87,12 @@ async function handleAuthRegister(payload: HandlerPayload<AuthLoginPayload>) {
 
     const accessToken = signJwt({ id: user.id });
     const refreshToken = generateRefreshToken(user.id.toString());
-    await insertRefreshToken(payload.state.db, user.id, refreshToken, new Date(Date.now() + 7 * 24 * 60 * 60 * 1000));
+    await insertRefreshToken(
+        payload.state.db,
+        user.id,
+        refreshToken,
+        new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+    );
 
     return buildSuccess(user, accessToken, refreshToken);
 }
@@ -92,7 +114,12 @@ async function handleAuthRefresh(payload: HandlerPayload<AuthRefreshPayload>) {
 
     const accessToken = signJwt({ id: user.id });
     const newToken = generateRefreshToken(user.id.toString());
-    await insertRefreshToken(payload.state.db, user.id, newToken, new Date(Date.now() + 7 * 24 * 60 * 60 * 1000));
+    await insertRefreshToken(
+        payload.state.db,
+        user.id,
+        newToken,
+        new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+    );
 
     const response: OpCode.AUTH_REFRESH_SUCCESS = OpCode.AUTH_REFRESH_SUCCESS;
     return { op: response, d: { accessToken, refreshToken: newToken } };

--- a/slice-guard/backend/src/ws/handlers/index.ts
+++ b/slice-guard/backend/src/ws/handlers/index.ts
@@ -1,13 +1,16 @@
-import { OpCode, type OpCodePayloadUnion, type OpCodeValue } from '@shared/ws/opcodes';
+import {
+  OpCode,
+  type OpCodePayloadUnion,
+  type OpCodeValue,
+} from "@shared/ws/opcodes";
 import * as auth from "../handlers/auth";
 import * as requestHandlers from "../handlers/request";
 import * as labHandlers from "../handlers/lab";
-import type State from '../../utils/state';
-import type { Logger } from 'pino';
-import type { ServerWebSocket } from '..';
-import { ErrorCode } from '@slice-guard/shared/ws/errors';
-import { verifyJwt } from '../../utils/jwt';
-
+import type State from "../../utils/state";
+import type { Logger } from "pino";
+import type { ServerWebSocket } from "..";
+import { ErrorCode } from "@slice-guard/shared/ws/errors";
+import { verifyJwt } from "../../utils/jwt";
 
 export class HandlerPayload<D> {
   public ws: ServerWebSocket;
@@ -25,14 +28,20 @@ export class HandlerPayload<D> {
 
 export type HandlerResponse = ErrorCode | OpCodePayloadUnion;
 
-export type Handler<D> = (payload: HandlerPayload<D>) => Promise<HandlerResponse>;
+export type Handler<D> = (
+  payload: HandlerPayload<D>
+) => Promise<HandlerResponse>;
 
 export interface AuthenticatedPayload<D> extends HandlerPayload<D> {
   userId: number;
 }
 
-export function withAuth<D>(handler: (payload: AuthenticatedPayload<D>) => Promise<HandlerResponse>): Handler<D & { d: { token: string } }> {
-  return async (payload: HandlerPayload<D & { d: { token: string } }>): Promise<HandlerResponse> => {
+export function withAuth<D>(
+  handler: (payload: AuthenticatedPayload<D>) => Promise<HandlerResponse>
+): Handler<D & { d: { token: string } }> {
+  return async (
+    payload: HandlerPayload<D & { d: { token: string } }>
+  ): Promise<HandlerResponse> => {
     let userId: number;
     try {
       const decoded = verifyJwt(payload.data.d.token) as any;
@@ -59,7 +68,8 @@ export type HandlerMap<K extends OpCodeValue = OpCodeValue> = Partial<{
  *
  * This is a union of all OpCodes that are handled by the server from the client as a request for some operation.
  */
-type HandlerMapItems = OpCode.AUTH_LOGIN
+type HandlerMapItems =
+  | OpCode.AUTH_LOGIN
   | OpCode.AUTH_REGISTER
   | OpCode.AUTH_REFRESH
   | OpCode.AUTH_LOGOUT
@@ -79,4 +89,4 @@ export const handlers: HandlerMap<HandlerMapItems> = {
   ...auth.handlers,
   ...requestHandlers.handlers,
   ...labHandlers.handlers,
-}
+};

--- a/slice-guard/backend/src/ws/handlers/index.ts
+++ b/slice-guard/backend/src/ws/handlers/index.ts
@@ -1,6 +1,7 @@
 import { OpCode, type OpCodePayloadUnion, type OpCodeValue } from '@shared/ws/opcodes';
 import * as auth from "../handlers/auth";
 import * as requestHandlers from "../handlers/request";
+import * as labHandlers from "../handlers/lab";
 import type State from '../../utils/state';
 import type { Logger } from 'pino';
 import type { ServerWebSocket } from '..';
@@ -66,9 +67,16 @@ type HandlerMapItems = OpCode.AUTH_LOGIN
   | OpCode.REQUEST_LIST
   | OpCode.TAG_CREATE
   | OpCode.TAG_SET_DEFAULT
-  | OpCode.REQUEST_ASSIGN_TAG;
+  | OpCode.REQUEST_ASSIGN_TAG
+  | OpCode.LAB_CREATE
+  | OpCode.LAB_UPDATE
+  | OpCode.LAB_DELETE
+  | OpCode.ROLE_CREATE
+  | OpCode.MEMBER_ADD
+  | OpCode.MEMBER_REMOVE;
 
 export const handlers: HandlerMap<HandlerMapItems> = {
   ...auth.handlers,
   ...requestHandlers.handlers,
+  ...labHandlers.handlers,
 }

--- a/slice-guard/backend/src/ws/handlers/lab.ts
+++ b/slice-guard/backend/src/ws/handlers/lab.ts
@@ -1,28 +1,70 @@
-import { OpCode, type LabCreatePayload, type LabUpdatePayload, type LabDeletePayload, type RoleCreatePayload, type MemberAddPayload, type MemberRemovePayload } from '@shared/ws/opcodes';
-import { withAuth, type AuthenticatedPayload, type HandlerMap } from '.';
-import { createLab, updateLab, deleteLab, createRole, addMember, removeMember, getMemberRolePermissions } from '../../db/lab';
-import { LabPermission } from '@shared/db/lab';
-import { ErrorCode } from '@slice-guard/shared/ws/errors';
+import {
+    OpCode,
+    type LabCreatePayload,
+    type LabUpdatePayload,
+    type LabDeletePayload,
+    type RoleCreatePayload,
+    type MemberAddPayload,
+    type MemberRemovePayload,
+} from "@shared/ws/opcodes";
+import { withAuth, type AuthenticatedPayload, type HandlerMap } from ".";
+import {
+    createLab,
+    updateLab,
+    deleteLab,
+    createRole,
+    addMember,
+    removeMember,
+    getMemberRolePermissions,
+} from "../../db/lab";
+import { LabPermission } from "@shared/db/lab";
+import { ErrorCode } from "@slice-guard/shared/ws/errors";
 
-async function handleCreateLab(payload: AuthenticatedPayload<LabCreatePayload>) {
+async function handleCreateLab(
+    payload: AuthenticatedPayload<LabCreatePayload>
+) {
     const { name, description, imageUrl } = payload.data.d;
-    const lab = await createLab(payload.state.db, payload.userId, name, description ?? null, imageUrl ?? null);
+    const lab = await createLab(
+        payload.state.db,
+        payload.userId,
+        name,
+        description ?? null,
+        imageUrl ?? null
+    );
     return { op: OpCode.LAB_CREATE, d: lab };
 }
 
-async function handleUpdateLab(payload: AuthenticatedPayload<LabUpdatePayload>) {
+async function handleUpdateLab(
+    payload: AuthenticatedPayload<LabUpdatePayload>
+) {
     const { labId, name, description, imageUrl } = payload.data.d;
-    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    const perms = await getMemberRolePermissions(
+        payload.state.db,
+        labId,
+        payload.userId
+    );
     if (perms === null || !(perms & LabPermission.EDIT_LAB)) {
         return ErrorCode.UNAUTHORIZED;
     }
-    const lab = await updateLab(payload.state.db, labId, name, description ?? null, imageUrl ?? null);
+    const lab = await updateLab(
+        payload.state.db,
+        labId,
+        name,
+        description ?? null,
+        imageUrl ?? null
+    );
     return { op: OpCode.LAB_UPDATE, d: lab };
 }
 
-async function handleDeleteLab(payload: AuthenticatedPayload<LabDeletePayload>) {
+async function handleDeleteLab(
+    payload: AuthenticatedPayload<LabDeletePayload>
+) {
     const { labId } = payload.data.d;
-    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    const perms = await getMemberRolePermissions(
+        payload.state.db,
+        labId,
+        payload.userId
+    );
     if (perms === null || !(perms & LabPermission.DELETE_LAB)) {
         return ErrorCode.UNAUTHORIZED;
     }
@@ -30,9 +72,15 @@ async function handleDeleteLab(payload: AuthenticatedPayload<LabDeletePayload>) 
     return { op: OpCode.LAB_DELETE, d: {} };
 }
 
-async function handleCreateRole(payload: AuthenticatedPayload<RoleCreatePayload>) {
+async function handleCreateRole(
+    payload: AuthenticatedPayload<RoleCreatePayload>
+) {
     const { labId, name, permissions } = payload.data.d;
-    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    const perms = await getMemberRolePermissions(
+        payload.state.db,
+        labId,
+        payload.userId
+    );
     if (perms === null || !(perms & LabPermission.MANAGE_ROLES)) {
         return ErrorCode.UNAUTHORIZED;
     }
@@ -40,9 +88,15 @@ async function handleCreateRole(payload: AuthenticatedPayload<RoleCreatePayload>
     return { op: OpCode.ROLE_CREATE, d: role };
 }
 
-async function handleAddMember(payload: AuthenticatedPayload<MemberAddPayload>) {
+async function handleAddMember(
+    payload: AuthenticatedPayload<MemberAddPayload>
+) {
     const { labId, userId, roleId } = payload.data.d;
-    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    const perms = await getMemberRolePermissions(
+        payload.state.db,
+        labId,
+        payload.userId
+    );
     if (perms === null || !(perms & LabPermission.MANAGE_ROLES)) {
         return ErrorCode.UNAUTHORIZED;
     }
@@ -50,9 +104,15 @@ async function handleAddMember(payload: AuthenticatedPayload<MemberAddPayload>) 
     return { op: OpCode.MEMBER_ADD, d: member };
 }
 
-async function handleRemoveMember(payload: AuthenticatedPayload<MemberRemovePayload>) {
+async function handleRemoveMember(
+    payload: AuthenticatedPayload<MemberRemovePayload>
+) {
     const { labId, userId } = payload.data.d;
-    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    const perms = await getMemberRolePermissions(
+        payload.state.db,
+        labId,
+        payload.userId
+    );
     if (perms === null || !(perms & LabPermission.REMOVE_USER)) {
         return ErrorCode.UNAUTHORIZED;
     }

--- a/slice-guard/backend/src/ws/handlers/lab.ts
+++ b/slice-guard/backend/src/ws/handlers/lab.ts
@@ -1,0 +1,70 @@
+import { OpCode, type LabCreatePayload, type LabUpdatePayload, type LabDeletePayload, type RoleCreatePayload, type MemberAddPayload, type MemberRemovePayload } from '@shared/ws/opcodes';
+import { withAuth, type AuthenticatedPayload, type HandlerMap } from '.';
+import { createLab, updateLab, deleteLab, createRole, addMember, removeMember, getMemberRolePermissions } from '../../db/lab';
+import { LabPermission } from '@shared/db/lab';
+import { ErrorCode } from '@slice-guard/shared/ws/errors';
+
+async function handleCreateLab(payload: AuthenticatedPayload<LabCreatePayload>) {
+    const { name, description, imageUrl } = payload.data.d;
+    const lab = await createLab(payload.state.db, payload.userId, name, description ?? null, imageUrl ?? null);
+    return { op: OpCode.LAB_CREATE, d: lab };
+}
+
+async function handleUpdateLab(payload: AuthenticatedPayload<LabUpdatePayload>) {
+    const { labId, name, description, imageUrl } = payload.data.d;
+    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    if (perms === null || !(perms & LabPermission.EDIT_LAB)) {
+        return ErrorCode.UNAUTHORIZED;
+    }
+    const lab = await updateLab(payload.state.db, labId, name, description ?? null, imageUrl ?? null);
+    return { op: OpCode.LAB_UPDATE, d: lab };
+}
+
+async function handleDeleteLab(payload: AuthenticatedPayload<LabDeletePayload>) {
+    const { labId } = payload.data.d;
+    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    if (perms === null || !(perms & LabPermission.DELETE_LAB)) {
+        return ErrorCode.UNAUTHORIZED;
+    }
+    await deleteLab(payload.state.db, labId);
+    return { op: OpCode.LAB_DELETE, d: {} };
+}
+
+async function handleCreateRole(payload: AuthenticatedPayload<RoleCreatePayload>) {
+    const { labId, name, permissions } = payload.data.d;
+    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    if (perms === null || !(perms & LabPermission.MANAGE_ROLES)) {
+        return ErrorCode.UNAUTHORIZED;
+    }
+    const role = await createRole(payload.state.db, labId, name, permissions);
+    return { op: OpCode.ROLE_CREATE, d: role };
+}
+
+async function handleAddMember(payload: AuthenticatedPayload<MemberAddPayload>) {
+    const { labId, userId, roleId } = payload.data.d;
+    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    if (perms === null || !(perms & LabPermission.MANAGE_ROLES)) {
+        return ErrorCode.UNAUTHORIZED;
+    }
+    const member = await addMember(payload.state.db, labId, userId, roleId);
+    return { op: OpCode.MEMBER_ADD, d: member };
+}
+
+async function handleRemoveMember(payload: AuthenticatedPayload<MemberRemovePayload>) {
+    const { labId, userId } = payload.data.d;
+    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    if (perms === null || !(perms & LabPermission.REMOVE_USER)) {
+        return ErrorCode.UNAUTHORIZED;
+    }
+    await removeMember(payload.state.db, labId, userId);
+    return { op: OpCode.MEMBER_REMOVE, d: {} };
+}
+
+export const handlers: HandlerMap = {
+    [OpCode.LAB_CREATE]: withAuth(handleCreateLab),
+    [OpCode.LAB_UPDATE]: withAuth(handleUpdateLab),
+    [OpCode.LAB_DELETE]: withAuth(handleDeleteLab),
+    [OpCode.ROLE_CREATE]: withAuth(handleCreateRole),
+    [OpCode.MEMBER_ADD]: withAuth(handleAddMember),
+    [OpCode.MEMBER_REMOVE]: withAuth(handleRemoveMember),
+};

--- a/slice-guard/backend/src/ws/handlers/request.ts
+++ b/slice-guard/backend/src/ws/handlers/request.ts
@@ -1,46 +1,94 @@
-import { OpCode, type RequestCreatePayload, type RequestListPayload, type TagCreatePayload, type TagSetDefaultPayload, type RequestAssignTagPayload } from '@shared/ws/opcodes';
-import { withAuth, type AuthenticatedPayload, type HandlerMap } from '.';
-import { createPrintRequest, getUserPrintRequests, createTag, setTagDefault, assignTag, unassignTag } from '../../db/request';
-import { saveRequestFile } from '../../utils/storage';
-import { getMemberRolePermissions } from '../../db/lab';
-import { LabPermission } from '@shared/db/lab';
-import { ErrorCode } from '@slice-guard/shared/ws/errors';
+import {
+    OpCode,
+    type RequestCreatePayload,
+    type RequestListPayload,
+    type TagCreatePayload,
+    type TagSetDefaultPayload,
+    type RequestAssignTagPayload,
+} from "@shared/ws/opcodes";
+import { withAuth, type AuthenticatedPayload, type HandlerMap } from ".";
+import {
+    createPrintRequest,
+    getUserPrintRequests,
+    createTag,
+    setTagDefault,
+    assignTag,
+    unassignTag,
+} from "../../db/request";
+import { saveRequestFile } from "../../utils/storage";
+import { getMemberRolePermissions } from "../../db/lab";
+import { LabPermission } from "@shared/db/lab";
+import { ErrorCode } from "@slice-guard/shared/ws/errors";
 
-async function handleCreateRequest(payload: AuthenticatedPayload<RequestCreatePayload>) {
+async function handleCreateRequest(
+    payload: AuthenticatedPayload<RequestCreatePayload>
+) {
     const { labId, file, metadata, description } = payload.data.d;
-    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    const perms = await getMemberRolePermissions(
+        payload.state.db,
+        labId,
+        payload.userId
+    );
     if (perms !== null && !(perms & LabPermission.CREATE_REQUEST)) {
         return ErrorCode.UNAUTHORIZED;
     }
-    const buffer = Buffer.from(file, 'base64');
+    const buffer = Buffer.from(file, "base64");
     const path = await saveRequestFile(labId, buffer);
-    const req = await createPrintRequest(payload.state.db, labId, payload.userId, path, metadata, description ?? null);
+    const req = await createPrintRequest(
+        payload.state.db,
+        labId,
+        payload.userId,
+        path,
+        metadata,
+        description ?? null
+    );
     return { op: OpCode.REQUEST_CREATE, d: req };
 }
 
-async function handleListRequests(payload: AuthenticatedPayload<RequestListPayload>) {
+async function handleListRequests(
+    payload: AuthenticatedPayload<RequestListPayload>
+) {
     const { labId } = payload.data.d;
-    const reqs = await getUserPrintRequests(payload.state.db, labId, payload.userId);
+    const reqs = await getUserPrintRequests(
+        payload.state.db,
+        labId,
+        payload.userId
+    );
     return { op: OpCode.REQUEST_LIST, d: reqs };
 }
 
-async function handleCreateTag(payload: AuthenticatedPayload<TagCreatePayload>) {
+async function handleCreateTag(
+    payload: AuthenticatedPayload<TagCreatePayload>
+) {
     const { labId, name, isDefault } = payload.data.d;
-    const perms = await getMemberRolePermissions(payload.state.db, labId, payload.userId);
+    const perms = await getMemberRolePermissions(
+        payload.state.db,
+        labId,
+        payload.userId
+    );
     if (perms === null || !(perms & LabPermission.MANAGE_ROLES)) {
         return ErrorCode.UNAUTHORIZED;
     }
-    const tag = await createTag(payload.state.db, labId, name, isDefault ?? false);
+    const tag = await createTag(
+        payload.state.db,
+        labId,
+        name,
+        isDefault ?? false
+    );
     return { op: OpCode.TAG_CREATE, d: tag };
 }
 
-async function handleSetDefault(payload: AuthenticatedPayload<TagSetDefaultPayload>) {
+async function handleSetDefault(
+    payload: AuthenticatedPayload<TagSetDefaultPayload>
+) {
     const { tagId, isDefault } = payload.data.d;
     const tag = await setTagDefault(payload.state.db, tagId, isDefault);
     return { op: OpCode.TAG_SET_DEFAULT, d: tag };
 }
 
-async function handleAssignTag(payload: AuthenticatedPayload<RequestAssignTagPayload>) {
+async function handleAssignTag(
+    payload: AuthenticatedPayload<RequestAssignTagPayload>
+) {
     const { requestId, tagId, assign } = payload.data.d;
     if (assign) {
         await assignTag(payload.state.db, requestId, tagId);

--- a/slice-guard/backend/tests/db.test.ts
+++ b/slice-guard/backend/tests/db.test.ts
@@ -11,25 +11,16 @@ import {
   type RefreshTokenRow,
 } from "../src/db/user";
 
-class MockDB {
-  public lastQuery: string | null = null;
-  public lastParams: any[] | null = null;
-  private result: any[];
-
-  constructor(result: any[] = []) {
-    this.result = result;
-  }
-
-  async query<T>(sql: string, params: any[]): Promise<T[]> {
-    this.lastQuery = sql;
-    this.lastParams = params;
-    return this.result as T[];
-  }
-
-  async run(sql: string, params: any[]): Promise<void> {
-    this.lastQuery = sql;
-    this.lastParams = params;
-  }
+function createMockSQL(result: any[] = []) {
+  const fn: any = (strings: TemplateStringsArray, ...values: any[]) => {
+    const query = strings.reduce((acc, str, i) => acc + str + (i < values.length ? `$${i + 1}` : ""), "");
+    fn.lastQuery = query;
+    fn.lastParams = values;
+    return Promise.resolve(result);
+  };
+  fn.lastQuery = null as string | null;
+  fn.lastParams = null as any[] | null;
+  return fn;
 }
 
 function normalize(sql: string | null) {
@@ -58,7 +49,7 @@ function sampleTokenRow(): RefreshTokenRow {
 
 test("findUserByEmail uses expected SQL", async () => {
   const row = sampleUser();
-  const db = new MockDB([row]);
+  const db = createMockSQL([row]);
   const result = await findUserByEmail(db as any, "test@example.com");
   expect(normalize(db.lastQuery)).toBe(
     "SELECT id, email, name, created_at, password_hash FROM auth.users WHERE email = $1"
@@ -69,7 +60,7 @@ test("findUserByEmail uses expected SQL", async () => {
 
 test("findUserById uses expected SQL", async () => {
   const row = sampleUser();
-  const db = new MockDB([row]);
+  const db = createMockSQL([row]);
   const result = await findUserById(db as any, 1);
   expect(normalize(db.lastQuery)).toBe(
     "SELECT id, email, name, created_at, password_hash FROM auth.users WHERE id = $1"
@@ -80,7 +71,7 @@ test("findUserById uses expected SQL", async () => {
 
 test("createUser inserts with expected values", async () => {
   const row = sampleUser();
-  const db = new MockDB([row]);
+  const db = createMockSQL([row]);
   const result = await createUser(db as any, row.email, row.password_hash, row.name!);
   expect(normalize(db.lastQuery)).toBe(
     "INSERT INTO auth.users (email, password_hash, name) VALUES ($1, $2, $3) RETURNING id, email, name, created_at, password_hash"
@@ -91,7 +82,7 @@ test("createUser inserts with expected values", async () => {
 
 test("insertRefreshToken uses expected SQL", async () => {
   const token = sampleTokenRow();
-  const db = new MockDB([token]);
+  const db = createMockSQL([token]);
   const result = await insertRefreshToken(db as any, token.user_id, token.token, token.expires_at);
   expect(normalize(db.lastQuery)).toBe(
     "INSERT INTO auth.refresh_tokens (user_id, token, expires_at) VALUES ($1, $2, $3) RETURNING id, user_id, token, created_at, expires_at"
@@ -102,7 +93,7 @@ test("insertRefreshToken uses expected SQL", async () => {
 
 test("getRefreshToken selects expected SQL", async () => {
   const token = sampleTokenRow();
-  const db = new MockDB([token]);
+  const db = createMockSQL([token]);
   const result = await getRefreshToken(db as any, token.token);
   expect(normalize(db.lastQuery)).toBe(
     "SELECT id, user_id, token, created_at, expires_at FROM auth.refresh_tokens WHERE token = $1"
@@ -112,7 +103,7 @@ test("getRefreshToken selects expected SQL", async () => {
 });
 
 test("deleteRefreshToken deletes by token", async () => {
-  const db = new MockDB();
+  const db = createMockSQL();
   await deleteRefreshToken(db as any, "abc");
   expect(normalize(db.lastQuery)).toBe(
     "DELETE FROM auth.refresh_tokens WHERE token = $1"
@@ -121,7 +112,7 @@ test("deleteRefreshToken deletes by token", async () => {
 });
 
 test("deleteTokensForUser deletes all for user", async () => {
-  const db = new MockDB();
+  const db = createMockSQL();
   await deleteTokensForUser(db as any, 2);
   expect(normalize(db.lastQuery)).toBe(
     "DELETE FROM auth.refresh_tokens WHERE user_id = $1"

--- a/slice-guard/backend/tests/lab.test.ts
+++ b/slice-guard/backend/tests/lab.test.ts
@@ -12,25 +12,16 @@ import {
   type LabMemberRow,
 } from "../src/db/lab";
 
-class MockDB {
-  public lastQuery: string | null = null;
-  public lastParams: any[] | null = null;
-  private result: any[];
-
-  constructor(result: any[] = []) {
-    this.result = result;
-  }
-
-  async query<T>(sql: string, params: any[]): Promise<T[]> {
-    this.lastQuery = sql;
-    this.lastParams = params;
-    return this.result as T[];
-  }
-
-  async run(sql: string, params: any[]): Promise<void> {
-    this.lastQuery = sql;
-    this.lastParams = params;
-  }
+function createMockSQL(result: any[] = []) {
+  const fn: any = (strings: TemplateStringsArray, ...values: any[]) => {
+    const query = strings.reduce((acc, str, i) => acc + str + (i < values.length ? `$${i + 1}` : ""), "");
+    fn.lastQuery = query;
+    fn.lastParams = values;
+    return Promise.resolve(result);
+  };
+  fn.lastQuery = null as string | null;
+  fn.lastParams = null as any[] | null;
+  return fn;
 }
 
 function normalize(sql: string | null) {
@@ -69,7 +60,7 @@ function sampleMember(): LabMemberRow {
 
 test("createLab inserts expected values", async () => {
   const lab = sampleLab();
-  const db = new MockDB([lab]);
+  const db = createMockSQL([lab]);
   const result = await createLab(db as any, lab.owner_id, lab.name, lab.description!, lab.image_url!);
   expect(normalize(db.lastQuery)).toBe(
     "INSERT INTO lab.labs (owner_id, name, description, image_url) VALUES ($1, $2, $3, $4) RETURNING id, owner_id, name, description, image_url, created_at"
@@ -79,7 +70,7 @@ test("createLab inserts expected values", async () => {
 });
 
 test("deleteLab deletes by id", async () => {
-  const db = new MockDB();
+  const db = createMockSQL();
   await deleteLab(db as any, 1);
   expect(normalize(db.lastQuery)).toBe("DELETE FROM lab.labs WHERE id = $1");
   expect(db.lastParams).toEqual([1]);
@@ -87,18 +78,18 @@ test("deleteLab deletes by id", async () => {
 
 test("updateLab updates fields", async () => {
   const lab = sampleLab();
-  const db = new MockDB([lab]);
+  const db = createMockSQL([lab]);
   const result = await updateLab(db as any, lab.id, lab.name, lab.description!, lab.image_url!);
   expect(normalize(db.lastQuery)).toBe(
-    "UPDATE lab.labs SET name = $2, description = $3, image_url = $4 WHERE id = $1 RETURNING id, owner_id, name, description, image_url, created_at"
+    "UPDATE lab.labs SET name = $1, description = $2, image_url = $3 WHERE id = $4 RETURNING id, owner_id, name, description, image_url, created_at"
   );
-  expect(db.lastParams).toEqual([lab.id, lab.name, lab.description, lab.image_url]);
+  expect(db.lastParams).toEqual([lab.name, lab.description, lab.image_url, lab.id]);
   expect(result).toEqual(lab);
 });
 
 test("createRole inserts expected values", async () => {
   const role = sampleRole();
-  const db = new MockDB([role]);
+  const db = createMockSQL([role]);
   const result = await createRole(db as any, role.lab_id, role.name, role.permissions as number);
   expect(normalize(db.lastQuery)).toBe(
     "INSERT INTO lab.roles (lab_id, name, permissions) VALUES ($1, $2, $3) RETURNING id, lab_id, name, permissions, created_at"
@@ -109,7 +100,7 @@ test("createRole inserts expected values", async () => {
 
 test("addMember inserts expected values", async () => {
   const m = sampleMember();
-  const db = new MockDB([m]);
+  const db = createMockSQL([m]);
   const result = await addMember(db as any, m.lab_id, m.user_id, m.role_id!);
   expect(normalize(db.lastQuery)).toBe(
     "INSERT INTO lab.members (lab_id, user_id, role_id) VALUES ($1, $2, $3) RETURNING lab_id, user_id, role_id, joined_at"
@@ -119,7 +110,7 @@ test("addMember inserts expected values", async () => {
 });
 
 test("removeMember deletes by composite id", async () => {
-  const db = new MockDB();
+  const db = createMockSQL();
   await removeMember(db as any, 1, 2);
   expect(normalize(db.lastQuery)).toBe(
     "DELETE FROM lab.members WHERE lab_id = $1 AND user_id = $2"
@@ -128,7 +119,7 @@ test("removeMember deletes by composite id", async () => {
 });
 
 test("getMemberRolePermissions selects join", async () => {
-  const db = new MockDB([{ permissions: 8 }]);
+  const db = createMockSQL([{ permissions: 8 }]);
   const result = await getMemberRolePermissions(db as any, 1, 2);
   expect(normalize(db.lastQuery)).toBe(
     "SELECT r.permissions FROM lab.members m JOIN lab.roles r ON m.role_id = r.id WHERE m.lab_id = $1 AND m.user_id = $2"

--- a/slice-guard/backend/tests/request.test.ts
+++ b/slice-guard/backend/tests/request.test.ts
@@ -11,25 +11,16 @@ import {
   type RequestTagRow,
 } from "../src/db/request";
 
-class MockDB {
-  public lastQuery: string | null = null;
-  public lastParams: any[] | null = null;
-  private result: any[];
-
-  constructor(result: any[] = []) {
-    this.result = result;
-  }
-
-  async query<T>(sql: string, params: any[]): Promise<T[]> {
-    this.lastQuery = sql;
-    this.lastParams = params;
-    return this.result as T[];
-  }
-
-  async run(sql: string, params: any[]): Promise<void> {
-    this.lastQuery = sql;
-    this.lastParams = params;
-  }
+function createMockSQL(result: any[] = []) {
+  const fn: any = (strings: TemplateStringsArray, ...values: any[]) => {
+    const query = strings.reduce((acc, str, i) => acc + str + (i < values.length ? `$${i + 1}` : ""), "");
+    fn.lastQuery = query;
+    fn.lastParams = values;
+    return Promise.resolve(result);
+  };
+  fn.lastQuery = null as string | null;
+  fn.lastParams = null as any[] | null;
+  return fn;
 }
 
 function normalize(sql: string | null) {
@@ -60,7 +51,7 @@ function sampleTag(): RequestTagRow {
 
 test("createPrintRequest inserts expected values", async () => {
   const req = sampleRequest();
-  const db = new MockDB([req]);
+  const db = createMockSQL([req]);
   const result = await createPrintRequest(db as any, req.lab_id, req.user_id, req.file_path, req.metadata, req.description!);
   expect(normalize(db.lastQuery)).toBe(
     "INSERT INTO lab.print_requests (lab_id, user_id, file_path, metadata, description) VALUES ($1, $2, $3, $4, $5) RETURNING id, lab_id, user_id, file_path, metadata, description, created_at"
@@ -71,7 +62,7 @@ test("createPrintRequest inserts expected values", async () => {
 
 test("getUserPrintRequests selects expected", async () => {
   const req = sampleRequest();
-  const db = new MockDB([req]);
+  const db = createMockSQL([req]);
   const result = await getUserPrintRequests(db as any, req.lab_id, req.user_id);
   expect(normalize(db.lastQuery)).toBe(
     "SELECT id, lab_id, user_id, file_path, metadata, description, created_at FROM lab.print_requests WHERE lab_id = $1 AND user_id = $2"
@@ -82,7 +73,7 @@ test("getUserPrintRequests selects expected", async () => {
 
 test("createTag inserts expected values", async () => {
   const tag = sampleTag();
-  const db = new MockDB([tag]);
+  const db = createMockSQL([tag]);
   const result = await createTag(db as any, tag.lab_id, tag.name, tag.is_default);
   expect(normalize(db.lastQuery)).toBe(
     "INSERT INTO lab.request_tags (lab_id, name, is_default) VALUES ($1, $2, $3) RETURNING id, lab_id, name, is_default, created_at"
@@ -93,17 +84,17 @@ test("createTag inserts expected values", async () => {
 
 test("setTagDefault updates flag", async () => {
   const tag = sampleTag();
-  const db = new MockDB([tag]);
+  const db = createMockSQL([tag]);
   const result = await setTagDefault(db as any, tag.id, true);
   expect(normalize(db.lastQuery)).toBe(
-    "UPDATE lab.request_tags SET is_default = $2 WHERE id = $1 RETURNING id, lab_id, name, is_default, created_at"
+    "UPDATE lab.request_tags SET is_default = $1 WHERE id = $2 RETURNING id, lab_id, name, is_default, created_at"
   );
-  expect(db.lastParams).toEqual([tag.id, true]);
+  expect(db.lastParams).toEqual([true, tag.id]);
   expect(result).toEqual(tag);
 });
 
 test("assignTag inserts mapping", async () => {
-  const db = new MockDB();
+  const db = createMockSQL();
   await assignTag(db as any, 1, 2);
   expect(normalize(db.lastQuery)).toBe(
     "INSERT INTO lab.request_tag_assignments (request_id, tag_id) VALUES ($1, $2) ON CONFLICT DO NOTHING"
@@ -112,7 +103,7 @@ test("assignTag inserts mapping", async () => {
 });
 
 test("unassignTag deletes mapping", async () => {
-  const db = new MockDB();
+  const db = createMockSQL();
   await unassignTag(db as any, 1, 2);
   expect(normalize(db.lastQuery)).toBe(
     "DELETE FROM lab.request_tag_assignments WHERE request_id = $1 AND tag_id = $2"
@@ -122,7 +113,7 @@ test("unassignTag deletes mapping", async () => {
 
 test("getTagsForRequest selects join", async () => {
   const tag = sampleTag();
-  const db = new MockDB([tag]);
+  const db = createMockSQL([tag]);
   const result = await getTagsForRequest(db as any, 1);
   expect(normalize(db.lastQuery)).toBe(
     "SELECT t.id, t.lab_id, t.name, t.is_default, t.created_at FROM lab.request_tag_assignments a JOIN lab.request_tags t ON a.tag_id = t.id WHERE a.request_id = $1"

--- a/slice-guard/shared/ws/opcodes.ts
+++ b/slice-guard/shared/ws/opcodes.ts
@@ -15,6 +15,12 @@ export enum OpCode {
     TAG_CREATE = 10,
     TAG_SET_DEFAULT = 11,
     REQUEST_ASSIGN_TAG = 12,
+    LAB_CREATE = 13,
+    LAB_UPDATE = 14,
+    LAB_DELETE = 15,
+    ROLE_CREATE = 16,
+    MEMBER_ADD = 17,
+    MEMBER_REMOVE = 18,
 }
 
 // Generic type for WebSocket payloads
@@ -105,3 +111,11 @@ export type RequestListPayload = OpCodePayload<OpCode.REQUEST_LIST> & { d: { lab
 export type TagCreatePayload = OpCodePayload<OpCode.TAG_CREATE> & { d: { labId: number; name: string; isDefault?: boolean; token: string } };
 export type TagSetDefaultPayload = OpCodePayload<OpCode.TAG_SET_DEFAULT> & { d: { tagId: number; isDefault: boolean; token: string } };
 export type RequestAssignTagPayload = OpCodePayload<OpCode.REQUEST_ASSIGN_TAG> & { d: { requestId: number; tagId: number; assign: boolean; token: string } };
+
+export type LabCreatePayload = OpCodePayload<OpCode.LAB_CREATE> & { d: { name: string; description?: string | null; imageUrl?: string | null; token: string } };
+export type LabUpdatePayload = OpCodePayload<OpCode.LAB_UPDATE> & { d: { labId: number; name: string; description?: string | null; imageUrl?: string | null; token: string } };
+export type LabDeletePayload = OpCodePayload<OpCode.LAB_DELETE> & { d: { labId: number; token: string } };
+export type RoleCreatePayload = OpCodePayload<OpCode.ROLE_CREATE> & { d: { labId: number; name: string; permissions: number; token: string } };
+export type MemberAddPayload = OpCodePayload<OpCode.MEMBER_ADD> & { d: { labId: number; userId: number; roleId: number | null; token: string } };
+export type MemberRemovePayload = OpCodePayload<OpCode.MEMBER_REMOVE> & { d: { labId: number; userId: number; token: string } };
+


### PR DESCRIPTION
## Summary
- use variable type annotations instead of generic `db` calls
- keep database queries typed through local variables

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_685c515cd038832082ad5ebd8bf8ad09