### PR TITLE
Add Vue Router scaffold

### DIFF
--- a/slice-guard/frontend/README.md
+++ b/slice-guard/frontend/README.md
@@ -1,6 +1,6 @@
 # Slice Guard Frontend
 
-This project uses **Vue 3**, **TypeScript**, **Vite** and **Tailwind CSS**. The default template has been removed and replaced with a minimal setup that supports light and dark themes.
+This project uses **Vue 3**, **TypeScript**, **Vite** and **Tailwind CSS**. The default template has been removed and replaced with a minimal setup that supports light and dark themes. Vue Router is configured for future page navigation.
 
 ## Development
 
@@ -24,7 +24,7 @@ src/
   styles/       global styles and tailwind configuration
 ```
 
-Only the `components` and `styles` directories exist initially. Create others as features are added.
+The project now includes `views` and `router` out of the box so routing can be expanded easily. Use these directories when adding new pages.
 
 ### Reusable Button Component
 
@@ -46,4 +46,4 @@ Only the `components` and `styles` directories exist initially. Create others as
 
 Reference these names in classes like `text-main` or `bg-surface`.
 
-Add or remove the `dark` class on the `html` element to toggle dark mode. `App.vue` includes a sample toggle button.
+Add or remove the `dark` class on the `html` element to toggle dark mode. `HomeView.vue` includes a sample toggle button.

--- a/slice-guard/frontend/package.json
+++ b/slice-guard/frontend/package.json
@@ -10,7 +10,8 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "vue-router": "^4.3.2"
   },
   "devDependencies": {
     "tailwindcss": "^3.4.4",

--- a/slice-guard/frontend/src/App.vue
+++ b/slice-guard/frontend/src/App.vue
@@ -1,33 +1,8 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
-import Button from './components/Button.vue'
-
-const isDark = ref(false)
-
-function applyTheme() {
-  const root = document.documentElement
-  if (isDark.value) root.classList.add('dark')
-  else root.classList.remove('dark')
-}
-
-function toggleTheme() {
-  isDark.value = !isDark.value
-  applyTheme()
-}
-
-onMounted(() => applyTheme())
 </script>
 
 <template>
-  <div class="min-h-screen flex items-center justify-center bg-background text-foreground transition-colors">
-    <div class="space-y-4 text-center">
-      <h1 class="text-4xl font-bold text-main">Slice Guard</h1>
-      <p class="text-accent-text">Modern 3D print management</p>
-      <Button variant="secondary" @click="toggleTheme">
-        Toggle {{ isDark ? 'Light' : 'Dark' }} Mode
-      </Button>
-    </div>
-  </div>
+  <router-view />
 </template>
 
 <style scoped>

--- a/slice-guard/frontend/src/main.ts
+++ b/slice-guard/frontend/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import './styles/main.css'
 import App from './App.vue'
+import router from './router'
 
-createApp(App).mount('#app')
+createApp(App).use(router).mount('#app')

--- a/slice-guard/frontend/src/router/index.ts
+++ b/slice-guard/frontend/src/router/index.ts
@@ -1,0 +1,17 @@
+import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
+import HomeView from '../views/HomeView.vue'
+
+const routes: RouteRecordRaw[] = [
+  {
+    path: '/',
+    name: 'Home',
+    component: HomeView,
+  },
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+})
+
+export default router

--- a/slice-guard/frontend/src/views/HomeView.vue
+++ b/slice-guard/frontend/src/views/HomeView.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import Button from '../components/Button.vue'
+
+const isDark = ref(false)
+
+function applyTheme() {
+  const root = document.documentElement
+  if (isDark.value) root.classList.add('dark')
+  else root.classList.remove('dark')
+}
+
+function toggleTheme() {
+  isDark.value = !isDark.value
+  applyTheme()
+}
+
+onMounted(() => applyTheme())
+</script>
+
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-background text-foreground transition-colors">
+    <div class="space-y-4 text-center">
+      <h1 class="text-4xl font-bold text-main">Slice Guard</h1>
+      <p class="text-accent-text">Modern 3D print management</p>
+      <Button variant="secondary" @click="toggleTheme">
+        Toggle {{ isDark ? 'Light' : 'Dark' }} Mode
+      </Button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+</style>


### PR DESCRIPTION
## Summary
- scaffold Vue Router in the frontend
- move demo page to `HomeView` and render it via router
- expose router from `src/router`
- document the router setup in README

## Testing
- `bun test --cwd slice-guard/backend`

------
https://chatgpt.com/codex/tasks/task_e_685c9029209c8320a38eb8c9d09326a2