### PR TITLE
Add dev/prod Docker stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,17 @@ The parser requires the `unzip` binary on the host system.
 ## Docker Setup
 
 An example `compose.yaml` and `.env.example` are provided for local development.
-After copying `.env.example` to `.env` you can build and start all services with:
+After copying `.env.example` to `.env` you can build and start the production
+containers with:
 
 ```bash
 docker compose up --build
+```
+
+During development start the services built from the `dev` stages instead:
+
+```bash
+docker compose --profile dev up --build
 ```
 
 The backend will be available on `http://localhost:3000` and the frontend on

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,6 +18,7 @@ services:
     build:
       context: ./slice-guard
       dockerfile: backend/Dockerfile
+      target: release
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-slice}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-slice}
@@ -35,12 +36,52 @@ services:
     build:
       context: ./slice-guard
       dockerfile: frontend/Dockerfile
+      target: release
       args:
         VITE_API_URL: http://backend:3000/api
         VITE_WS_URL: ws://backend:3000/ws
     depends_on:
       - backend
     restart: unless-stopped
+    ports:
+      - "5173:5173"
+
+  backend-dev:
+    profiles: ["dev"]
+    build:
+      context: ./slice-guard
+      dockerfile: backend/Dockerfile
+      target: dev
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-slice}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-slice}
+      POSTGRES_DB: ${POSTGRES_DB:-slice_guard}
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+    volumes:
+      - ./slice-guard/backend:/usr/src/app/backend
+      - /usr/src/app/backend/node_modules
+      - ./slice-guard/shared:/usr/src/app/shared
+    depends_on:
+      - postgres
+    ports:
+      - "3000:3000"
+
+  frontend-dev:
+    profiles: ["dev"]
+    build:
+      context: ./slice-guard
+      dockerfile: frontend/Dockerfile
+      target: dev
+      args:
+        VITE_API_URL: http://backend-dev:3000/api
+        VITE_WS_URL: ws://backend-dev:3000/ws
+    volumes:
+      - ./slice-guard/frontend:/usr/src/app
+      - /usr/src/app/node_modules
+      - ./slice-guard/shared:/usr/src/app/shared
+    depends_on:
+      - backend-dev
     ports:
       - "5173:5173"
 

--- a/slice-guard/backend/Dockerfile
+++ b/slice-guard/backend/Dockerfile
@@ -5,39 +5,35 @@ WORKDIR /usr/src/app
 
 # install dependencies into temp directory
 # this will cache them and speed up future builds
-FROM base AS install
-RUN mkdir -p /temp/dev
-COPY backend/package.json /temp/dev/
-RUN cd /temp/dev && bun install --frozen-lockfile
+# install dependencies
+FROM base AS deps
+COPY bun.lock ./bun.lock
+COPY backend/package.json ./backend/package.json
+RUN bun install --cwd ./backend --frozen-lockfile
 
-# install with --production (exclude devDependencies)
-RUN mkdir -p /temp/prod
-COPY backend/package.json /temp/prod/
-RUN cd /temp/prod && bun install --frozen-lockfile --production
-
-# copy node_modules from temp directory
-# then copy all (non-ignored) project files into the image
-FROM base AS prerelease
-# Create directory for the shared contents
-COPY --from=install /temp/dev/node_modules node_modules
+# development image
+FROM base AS dev
+WORKDIR /usr/src/app
+COPY --from=deps /usr/src/app/backend/node_modules ./backend/node_modules
 COPY backend/ ./backend
-COPY shared/ ./shared/
-
-# [optional] tests & build
-ENV NODE_ENV=production
-# RUN bun test
-# RUN bun run build
-
-
-# copy production dependencies and source code into final image
-FROM base AS release
-COPY --from=install /temp/prod/node_modules ./backend/node_modules
-COPY --from=prerelease /usr/src/app/shared ./shared
-COPY --from=prerelease /usr/src/app/backend/ ./backend/
-COPY --from=prerelease /usr/src/app/backend/package.json ./backend
-
-
-# run the app
+COPY shared/ ./shared
 USER bun
-EXPOSE 3000/tcp
-ENTRYPOINT [ "bun", "run", "backend/src/server.ts" ]
+EXPOSE 3000
+CMD ["bun", "run", "--cwd", "./backend", "dev"]
+
+# build binary
+FROM base AS build
+WORKDIR /usr/src/app
+COPY --from=deps /usr/src/app/backend/node_modules ./backend/node_modules
+COPY backend/ ./backend
+COPY shared/ ./shared
+RUN bun run build --cwd ./backend
+
+# production image
+FROM base AS release
+WORKDIR /usr/src/app
+COPY --from=build /usr/src/app/backend/dist/server ./server
+COPY shared/ ./shared
+USER bun
+EXPOSE 3000
+ENTRYPOINT ["./server"]

--- a/slice-guard/backend/package.json
+++ b/slice-guard/backend/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "start": "bun run src/server.ts",
         "dev": "bun run src/server.ts --watch",
-        "build": "bun build ./src/server.ts --target=bun",
+        "build": "bun build ./src/server.ts --target=bun --outfile=dist/server",
         "test": "bun test"
     },
     "dependencies": {

--- a/slice-guard/frontend/Dockerfile
+++ b/slice-guard/frontend/Dockerfile
@@ -1,10 +1,21 @@
 # Stage 1: install dependencies
 FROM oven/bun:1 AS deps
 WORKDIR /usr/src/app
+COPY bun.lock ./bun.lock
 COPY frontend/package.json ./package.json
 RUN bun install --frozen-lockfile
 
-# Stage 2: build frontend
+# Stage 2: development image
+FROM oven/bun:1 AS dev
+WORKDIR /usr/src/app
+COPY --from=deps /usr/src/app/node_modules ./node_modules
+COPY frontend/ .
+COPY shared/ ./shared
+USER bun
+EXPOSE 5173
+CMD ["bun", "run", "dev"]
+
+# Stage 3: build frontend
 FROM oven/bun:1 AS build
 WORKDIR /usr/src/app
 COPY --from=deps /usr/src/app/node_modules ./node_modules
@@ -16,7 +27,7 @@ ENV VITE_API_URL=$VITE_API_URL
 ENV VITE_WS_URL=$VITE_WS_URL
 RUN bun run build
 
-# Stage 3: production image
+# Stage 4: production image
 FROM oven/bun:1 AS release
 WORKDIR /usr/src/app
 COPY --from=build /usr/src/app/node_modules ./node_modules

--- a/slice-guard/frontend/package.json
+++ b/slice-guard/frontend/package.json
@@ -21,6 +21,7 @@
     "@vue/tsconfig": "^0.7.0",
     "typescript": "~5.8.3",
     "vite": "^6.3.5",
-    "vue-tsc": "^2.2.8"
+    "vue-tsc": "^2.2.8",
+    "esbuild": "0.25.5"
   }
 }


### PR DESCRIPTION
## Summary
- add esbuild dependency for frontend
- produce a binary during backend build
- add dev image targets for backend and frontend
- support dev vs release in `compose.yaml`
- document how to run dev profile with compose
- keep node modules when mounting source for dev containers
- pin dependencies using bun.lock

## Testing
- `bun test ./slice-guard/backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_685ef6817ebc832080c5daa3dd530324