### PR TITLE
Add member roles table and default role tracking

### DIFF
--- a/slice-guard/backend/migrations/005_member_roles.sql
+++ b/slice-guard/backend/migrations/005_member_roles.sql
@@ -1,0 +1,13 @@
+ALTER TABLE lab.labs ADD COLUMN default_role_id INTEGER;
+ALTER TABLE lab.labs ADD CONSTRAINT labs_default_role_fkey FOREIGN KEY (default_role_id)
+    REFERENCES lab.roles(id) ON DELETE SET NULL;
+
+ALTER TABLE lab.members DROP COLUMN role_id;
+
+CREATE TABLE lab.member_roles (
+    lab_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    role_id INTEGER NOT NULL REFERENCES lab.roles(id) ON DELETE CASCADE,
+    PRIMARY KEY (lab_id, user_id, role_id),
+    FOREIGN KEY (lab_id, user_id) REFERENCES lab.members(lab_id, user_id) ON DELETE CASCADE
+);

--- a/slice-guard/backend/src/db/lab.ts
+++ b/slice-guard/backend/src/db/lab.ts
@@ -3,7 +3,18 @@ import type { SQL } from "bun";
 
 export interface LabRow extends Lab { }
 export interface LabRoleRow extends LabRole { }
-export interface LabMemberRow extends LabMember { }
+// Database representation of a lab member row
+export interface LabMemberRow {
+    lab_id: number;
+    user_id: number;
+    joined_at: Date;
+}
+
+export interface MemberRoleRow {
+    lab_id: number;
+    user_id: number;
+    role_id: number;
+}
 
 export async function createLab(
     db: SQL,
@@ -15,14 +26,20 @@ export async function createLab(
     const rows: LabRow[] = await db`
         INSERT INTO lab.labs (owner_id, name, description, image_url)
              VALUES (${ownerId}, ${name}, ${description}, ${imageUrl})
-        RETURNING id, owner_id, name, description, image_url, created_at
+        RETURNING id, owner_id, name, description, image_url, default_role_id, created_at
     `;
     const lab: LabRow = rows[0];
 
     // Create a default role for every member, @everyone
     const role = await createRole(db, lab.id, "everyone", LabPermission.READ | LabPermission.WRITE);
+    await db`
+        UPDATE lab.labs
+           SET default_role_id = ${role.id}
+         WHERE id = ${lab.id}
+    `;
+    lab.default_role_id = role.id;
 
-    // Add this owner to the member list
+    // Add this owner to the member list with the default role
     await addMember(db, lab.id, ownerId, role.id);
     return lab;
 }
@@ -68,14 +85,33 @@ export async function addMember(
     db: SQL,
     labId: number,
     userId: number,
-    roleId: number | null
+    roleId: number | null = null
 ): Promise<LabMemberRow> {
     const rows: LabMemberRow[] = await db`
-        INSERT INTO lab.members (lab_id, user_id, role_id)
-             VALUES (${labId}, ${userId}, ${roleId})
-        RETURNING lab_id, user_id, role_id, joined_at
+        INSERT INTO lab.members (lab_id, user_id)
+             VALUES (${labId}, ${userId})
+        RETURNING lab_id, user_id, joined_at
     `;
-    return rows[0];
+    const member = rows[0];
+
+    const [{ default_role_id }] = await db`
+        SELECT default_role_id FROM lab.labs WHERE id = ${labId}
+    `;
+
+    if (default_role_id !== null && default_role_id !== undefined) {
+        await db`
+            INSERT INTO lab.member_roles (lab_id, user_id, role_id)
+                 VALUES (${labId}, ${userId}, ${default_role_id})
+        `;
+    }
+    if (roleId !== null && roleId !== default_role_id) {
+        await db`
+            INSERT INTO lab.member_roles (lab_id, user_id, role_id)
+                 VALUES (${labId}, ${userId}, ${roleId})
+        `;
+    }
+
+    return member;
 }
 
 export async function removeMember(
@@ -91,12 +127,21 @@ export async function removeMember(
 
 export async function getMember(db: SQL, labId: number, userId: number): Promise<LabMemberRow | null> {
     const rows: LabMemberRow[] = await db`
-        SELECT lab_id, user_id, role_id, joined_at
+        SELECT lab_id, user_id, joined_at
           FROM lab.members
          WHERE lab_id = ${labId} AND user_id = ${userId}
     `;
     const [row] = rows;
     return row ?? null;
+}
+
+export async function listMembers(db: SQL, labId: number): Promise<LabMemberRow[]> {
+    const rows: LabMemberRow[] = await db`
+        SELECT lab_id, user_id, joined_at
+          FROM lab.members
+         WHERE lab_id = ${labId}
+    `;
+    return rows;
 }
 
 export async function getMemberRolePermissions(
@@ -106,12 +151,12 @@ export async function getMemberRolePermissions(
 ): Promise<number | null> {
     const rows: { permissions: number }[] = await db`
         SELECT r.permissions
-          FROM lab.members m
-          JOIN lab.roles r ON m.role_id = r.id
-         WHERE m.lab_id = ${labId} AND m.user_id = ${userId}
+          FROM lab.member_roles mr
+          JOIN lab.roles r ON mr.role_id = r.id
+         WHERE mr.lab_id = ${labId} AND mr.user_id = ${userId}
     `;
-    const [row] = rows;
-    return row ? row.permissions : null;
+    if (rows.length === 0) return null;
+    return rows.reduce((acc, r) => acc | Number(r.permissions), 0);
 }
 
 export async function getMemberRoles(
@@ -121,16 +166,17 @@ export async function getMemberRoles(
 ): Promise<LabRoleRow[]> {
     const rows: LabRoleRow[] = await db`
         SELECT r.id, r.lab_id, r.name, r.permissions, r.created_at
-          FROM lab.members m
-          JOIN lab.roles r ON m.role_id = r.id
-         WHERE m.lab_id = ${labId} AND m.user_id = ${userId}
+          FROM lab.member_roles mr
+          JOIN lab.roles r ON mr.role_id = r.id
+         WHERE mr.lab_id = ${labId} AND mr.user_id = ${userId}
+         ORDER BY r.id
     `;
     return rows;
 }
 
 export async function getLab(db: SQL, id: number): Promise<LabRow | null> {
     const rows: LabRow[] = await db`
-        SELECT id, owner_id, name, description, image_url, created_at
+        SELECT id, owner_id, name, description, image_url, default_role_id, created_at
           FROM lab.labs
          WHERE id = ${id}
     `;
@@ -139,7 +185,7 @@ export async function getLab(db: SQL, id: number): Promise<LabRow | null> {
 
 export async function listLabsForUser(db: SQL, userId: number): Promise<LabRow[]> {
     const rows: LabRow[] = await db`
-        SELECT l.id, l.owner_id, l.name, l.description, l.image_url, l.created_at
+        SELECT l.id, l.owner_id, l.name, l.description, l.image_url, l.default_role_id, l.created_at
           FROM lab.labs l
           JOIN lab.members m ON m.lab_id = l.id
          WHERE m.user_id = ${userId}

--- a/slice-guard/backend/src/db/user.ts
+++ b/slice-guard/backend/src/db/user.ts
@@ -50,6 +50,17 @@ export async function findUserById(db: SQL, id: number): Promise<UserWithPasswor
     return row ?? null;
 }
 
+/** Fetch a user by id returning only public fields. */
+export async function findPublicUserById(db: SQL, id: number): Promise<User | null> {
+    const rows: User[] = await db`
+        SELECT id, email, name, created_at
+          FROM auth.users
+         WHERE id = ${id}
+    `;
+    const [row] = rows;
+    return row ?? null;
+}
+
 /** Create a new user in the database. */
 export async function createUser(db: SQL, email: string, passwordHash: string, name: string): Promise<UserWithPassword> {
     const rows: UserWithPassword[] = await db`

--- a/slice-guard/backend/src/http/lab.ts
+++ b/slice-guard/backend/src/http/lab.ts
@@ -14,7 +14,7 @@ import {
     listLabsForUser,
 } from "../db/lab";
 import { findPublicUserById } from "../db/user";
-import { LabPermission } from "@shared/db/lab";
+import { LabPermission, type LabMember } from "@shared/db/lab";
 import type {
     LabCreatePayload,
     LabUpdatePayload,

--- a/slice-guard/backend/src/http/lab.ts
+++ b/slice-guard/backend/src/http/lab.ts
@@ -6,10 +6,14 @@ import {
     createRole,
     addMember,
     removeMember,
+    getMember,
+    listMembers,
+    getMemberRoles,
     getMemberRolePermissions,
     getLab,
     listLabsForUser,
 } from "../db/lab";
+import { findPublicUserById } from "../db/user";
 import { LabPermission } from "@shared/db/lab";
 import type {
     LabCreatePayload,
@@ -133,3 +137,57 @@ export const removeMemberRoute = withAuth(async (req, userId, state, params) => 
     return new Response(null, { status: 204 });
 }
 );
+
+/**
+ * GET /api/labs/:labId/members/:userId
+ */
+export const getMemberRoute = withAuth(async (_req, userId, state, params) => {
+    const labId = Number(params.labId);
+    const targetId = Number(params.userId);
+
+    const perms = await getMemberRolePermissions(state.db, labId, userId);
+    if (perms === null) return new Response("Unauthorized", { status: 403 });
+
+    const row = await getMember(state.db, labId, targetId);
+    if (!row) return new Response("Not found", { status: 404 });
+
+    const user = await findPublicUserById(state.db, targetId);
+    if (!user) return new Response("Not found", { status: 404 });
+
+    const roles = await getMemberRoles(state.db, labId, targetId);
+    const member: LabMember = {
+        lab_id: row.lab_id,
+        user_id: row.user_id,
+        roles,
+        joined_at: row.joined_at,
+    };
+
+    return Response.json({ member, user });
+});
+
+/**
+ * GET /api/labs/:labId/members
+ */
+export const listMembersRoute = withAuth(async (_req, userId, state, params) => {
+    const labId = Number(params.labId);
+
+    const perms = await getMemberRolePermissions(state.db, labId, userId);
+    if (perms === null) return new Response("Unauthorized", { status: 403 });
+
+    const rows = await listMembers(state.db, labId);
+    const results = [] as any[];
+    for (const row of rows) {
+        const user = await findPublicUserById(state.db, row.user_id);
+        if (!user) continue;
+        const roles = await getMemberRoles(state.db, labId, row.user_id);
+        const member: LabMember = {
+            lab_id: row.lab_id,
+            user_id: row.user_id,
+            roles,
+            joined_at: row.joined_at,
+        };
+        results.push({ member, user });
+    }
+
+    return Response.json(results);
+});

--- a/slice-guard/backend/src/server.ts
+++ b/slice-guard/backend/src/server.ts
@@ -48,9 +48,11 @@ export class Server {
                 },
                 '/api/labs/:labId/members': {
                     POST: req => withLogging(lab.addMemberRoute)(req, this.state, req.params),
+                    GET: req => withLogging(lab.listMembersRoute)(req, this.state, req.params),
                 },
                 '/api/labs/:labId/members/:userId': {
                     DELETE: req => withLogging(lab.removeMemberRoute)(req, this.state, req.params),
+                    GET: req => withLogging(lab.getMemberRoute)(req, this.state, req.params),
                 },
                 '/api/labs/:labId/requests': {
                     POST: req => withLogging(requestHandlers.create)(req, this.state, req.params),

--- a/slice-guard/backend/tests/lab.test.ts
+++ b/slice-guard/backend/tests/lab.test.ts
@@ -6,21 +6,26 @@ import {
   createRole,
   addMember,
   removeMember,
+  listMembers,
   getMemberRolePermissions,
   type LabRow,
   type LabRoleRow,
   type LabMemberRow,
 } from "../src/db/lab";
 
-function createMockSQL(result: any[] = []) {
+function createMockSQL(results: any[] = []) {
   const fn: any = (strings: TemplateStringsArray, ...values: any[]) => {
-    const query = strings.reduce((acc, str, i) => acc + str + (i < values.length ? `$${i + 1}` : ""), "");
-    fn.lastQuery = query;
-    fn.lastParams = values;
-    return Promise.resolve(result);
+    const query = strings.reduce(
+      (acc, str, i) => acc + str + (i < values.length ? `$${i + 1}` : ""),
+      ""
+    );
+    fn.queries.push(query);
+    fn.params.push(values);
+    const res = results.length ? results.shift() : [];
+    return Promise.resolve(res);
   };
-  fn.lastQuery = null as string | null;
-  fn.lastParams = null as any[] | null;
+  fn.queries = [] as string[];
+  fn.params = [] as any[][];
   return fn;
 }
 
@@ -35,6 +40,7 @@ function sampleLab(): LabRow {
     name: "Test Lab",
     description: "Desc",
     image_url: "img",
+    default_role_id: 1,
     created_at: new Date(),
   };
 }
@@ -53,7 +59,6 @@ function sampleMember(): LabMemberRow {
   return {
     lab_id: 1,
     user_id: 2,
-    role_id: 1,
     joined_at: new Date(),
   };
 }
@@ -75,58 +80,73 @@ function sampleMember(): LabMemberRow {
 test("deleteLab deletes by id", async () => {
   const db = createMockSQL();
   await deleteLab(db as any, 1);
-  expect(normalize(db.lastQuery)).toBe("DELETE FROM lab.labs WHERE id = $1");
-  expect(db.lastParams).toEqual([1]);
+  expect(normalize(db.queries.at(-1))).toBe("DELETE FROM lab.labs WHERE id = $1");
+  expect(db.params.at(-1)).toEqual([1]);
 });
 
 test("updateLab updates fields", async () => {
   const lab = sampleLab();
-  const db = createMockSQL([lab]);
+  const db = createMockSQL([[lab]]);
   const result = await updateLab(db as any, lab.id, lab.name, lab.description!, lab.image_url!);
-  expect(normalize(db.lastQuery)).toBe(
+  expect(normalize(db.queries.at(-1))).toBe(
     "UPDATE lab.labs SET name = $1, description = $2, image_url = $3 WHERE id = $4 RETURNING id, owner_id, name, description, image_url, created_at"
   );
-  expect(db.lastParams).toEqual([lab.name, lab.description, lab.image_url, lab.id]);
+  expect(db.params.at(-1)).toEqual([lab.name, lab.description, lab.image_url, lab.id]);
   expect(result).toEqual(lab);
 });
 
 test("createRole inserts expected values", async () => {
   const role = sampleRole();
-  const db = createMockSQL([role]);
+  const db = createMockSQL([[role]]);
   const result = await createRole(db as any, role.lab_id, role.name, role.permissions as number);
-  expect(normalize(db.lastQuery)).toBe(
+  expect(normalize(db.queries.at(-1))).toBe(
     "INSERT INTO lab.roles (lab_id, name, permissions) VALUES ($1, $2, $3) RETURNING id, lab_id, name, permissions, created_at"
   );
-  expect(db.lastParams).toEqual([role.lab_id, role.name, role.permissions]);
+  expect(db.params.at(-1)).toEqual([role.lab_id, role.name, role.permissions]);
   expect(result).toEqual(role);
 });
 
-test("addMember inserts expected values", async () => {
+test("addMember inserts member row", async () => {
   const m = sampleMember();
-  const db = createMockSQL([m]);
-  const result = await addMember(db as any, m.lab_id, m.user_id, m.role_id!);
-  expect(normalize(db.lastQuery)).toBe(
-    "INSERT INTO lab.members (lab_id, user_id, role_id) VALUES ($1, $2, $3) RETURNING lab_id, user_id, role_id, joined_at"
+  const db = createMockSQL([[m], [{ default_role_id: 1 }]]);
+  const result = await addMember(db as any, m.lab_id, m.user_id, 2);
+  expect(normalize(db.queries[0])).toBe(
+    "INSERT INTO lab.members (lab_id, user_id) VALUES ($1, $2) RETURNING lab_id, user_id, joined_at"
   );
-  expect(db.lastParams).toEqual([m.lab_id, m.user_id, m.role_id]);
+  expect(db.params[0]).toEqual([m.lab_id, m.user_id]);
+  expect(normalize(db.queries[3])).toBe(
+    "INSERT INTO lab.member_roles (lab_id, user_id, role_id) VALUES ($1, $2, $3)"
+  );
+  expect(db.params[3]).toEqual([m.lab_id, m.user_id, 2]);
   expect(result).toEqual(m);
 });
 
 test("removeMember deletes by composite id", async () => {
   const db = createMockSQL();
   await removeMember(db as any, 1, 2);
-  expect(normalize(db.lastQuery)).toBe(
+  expect(normalize(db.queries.at(-1))).toBe(
     "DELETE FROM lab.members WHERE lab_id = $1 AND user_id = $2"
   );
-  expect(db.lastParams).toEqual([1, 2]);
+  expect(db.params.at(-1)).toEqual([1, 2]);
 });
 
 test("getMemberRolePermissions selects join", async () => {
-  const db = createMockSQL([{ permissions: 8 }]);
+  const db = createMockSQL([[{ permissions: 8 }]]);
   const result = await getMemberRolePermissions(db as any, 1, 2);
-  expect(normalize(db.lastQuery)).toBe(
-    "SELECT r.permissions FROM lab.members m JOIN lab.roles r ON m.role_id = r.id WHERE m.lab_id = $1 AND m.user_id = $2"
+  expect(normalize(db.queries.at(-1))).toBe(
+    "SELECT r.permissions FROM lab.member_roles mr JOIN lab.roles r ON mr.role_id = r.id WHERE mr.lab_id = $1 AND mr.user_id = $2"
   );
-  expect(db.lastParams).toEqual([1, 2]);
+  expect(db.params.at(-1)).toEqual([1, 2]);
   expect(result).toEqual(8);
+});
+
+test("listMembers selects expected", async () => {
+  const m = sampleMember();
+  const db = createMockSQL([[m]]);
+  const result = await listMembers(db as any, m.lab_id);
+  expect(normalize(db.queries.at(-1))).toBe(
+    "SELECT lab_id, user_id, joined_at FROM lab.members WHERE lab_id = $1"
+  );
+  expect(db.params.at(-1)).toEqual([m.lab_id]);
+  expect(result).toEqual([m]);
 });

--- a/slice-guard/frontend/README.md
+++ b/slice-guard/frontend/README.md
@@ -29,21 +29,3 @@ The project now includes `views` and `router` out of the box so routing can be e
 ### Reusable Button Component
 
 `src/components/Button.vue` exposes a small button with `primary` and `secondary` variants. Use it throughout the app for consistent styling.
-
-## Tailwind and Theme
-
-`tailwind.config.cjs` exposes a comprehensive set of colour variables. The palette follows Apple's soft tones:
-
-- `main` – lighter British Racing Green (`#005e3c` in light mode, `#1ba56e` in dark mode)
-- `accent` – modern highlight (`#30d158`)
-- `accent-text` – black in light mode, white in dark mode
-- `background`/`surface` – page and card backgrounds
-- `foreground`/`muted` – primary and secondary text colours
-- `border` – subtle outlines
-- `gray-1`, `gray-2`, `gray-3` – neutral tiers for layouts
-- `success`, `warning`, `error`, `info` – status colours
-- `white` and `black` remain available
-
-Reference these names in classes like `text-main` or `bg-surface`.
-
-Add or remove the `dark` class on the `html` element to toggle dark mode. The project includes a sample toggle button in earlier demos.

--- a/slice-guard/frontend/src/components/Button.vue
+++ b/slice-guard/frontend/src/components/Button.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const props = defineProps({
+defineProps({
   variant: {
     type: String as () => 'primary' | 'secondary',
     default: 'primary'
@@ -12,7 +12,7 @@ const props = defineProps({
     'px-4 py-2 rounded-xl transition-colors shadow',
     variant === 'primary'
       ? 'bg-salem-800 text-white hover:bg-salem-800/90 font-medium'
-      : 'bg-gray-1 text-salem-800 hover:bg-gray2 outline outline-salem-800'
+      : 'bg-surface-low text-salem-800 hover:bg-gray2 ring ring-salem-800 dark:ring-0 dark:inset-shadow-2xs dark:shadow-fg-secondary'
   ]">
     <slot />
   </button>

--- a/slice-guard/frontend/src/components/Button.vue
+++ b/slice-guard/frontend/src/components/Button.vue
@@ -11,8 +11,8 @@ const props = defineProps({
   <button :class="[
     'px-4 py-2 rounded-xl transition-colors shadow',
     variant === 'primary'
-      ? 'bg-main text-white hover:bg-main/90 font-medium'
-      : 'bg-gray-1 text-main hover:bg-gray2 outline outline-main outline-1'
+      ? 'bg-salem-800 text-white hover:bg-salem-800/90 font-medium'
+      : 'bg-gray-1 text-salem-800 hover:bg-gray2 outline outline-salem-800'
   ]">
     <slot />
   </button>

--- a/slice-guard/frontend/src/components/ThemeToggle.vue
+++ b/slice-guard/frontend/src/components/ThemeToggle.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import Button from './Button.vue';
+
+const isDark = ref(false)
+
+// Initialize theme from localStorage or system preference
+onMounted(() => {
+    const savedTheme = localStorage.getItem('theme')
+    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+
+    isDark.value = savedTheme ? savedTheme === 'dark' : systemPrefersDark
+    applyTheme()
+})
+
+function toggleTheme() {
+    isDark.value = !isDark.value
+    applyTheme()
+}
+
+function applyTheme() {
+    if (isDark.value) {
+        document.documentElement.classList.add('dark')
+        document.documentElement.classList.remove('light')
+        localStorage.setItem('theme', 'dark')
+    } else {
+        document.documentElement.classList.add('light')
+        document.documentElement.classList.remove('dark')
+        localStorage.setItem('theme', 'light')
+    }
+}
+</script>
+
+<template>
+    <Button @click="toggleTheme" variant="secondary">
+        {{ isDark ? '☀️' : '🌙' }}
+    </Button>
+</template>

--- a/slice-guard/frontend/src/router/index.ts
+++ b/slice-guard/frontend/src/router/index.ts
@@ -23,13 +23,18 @@ const routes: RouteRecordRaw[] = [
       },
       {
         path: ':id',
-    component: () => import('../views/lab/LabLayout.vue'),
+        component: () => import('../views/lab/LabLayout.vue'),
         children: [
           {
             path: '',
             name: 'LabDashboard',
             component: () => import('../views/lab/LabDashboard.vue'),
           },
+          {
+            path: 'print-requests',
+            name: 'LabPrintRequests',
+            component: () => import('../views/lab/LabPrintRequests.vue'),
+          }
         ],
       },
     ],

--- a/slice-guard/frontend/src/store/auth.ts
+++ b/slice-guard/frontend/src/store/auth.ts
@@ -4,18 +4,20 @@ import type { User } from '@shared/db/user'
 export const useAuthStore = defineStore('auth', {
   state: () => ({
     apiKey: localStorage.getItem('apiKey') as string | null,
-    user: null as User | null,
+    user: JSON.parse(localStorage.getItem('user') || 'null') as User | null,
   }),
   actions: {
     setSession(apiKey: string, user: User) {
       this.apiKey = apiKey
       this.user = user
       localStorage.setItem('apiKey', apiKey)
+      localStorage.setItem('user', JSON.stringify(user))
     },
     clearSession() {
       this.apiKey = null
       this.user = null
       localStorage.removeItem('apiKey')
+      localStorage.removeItem('user')
     },
   },
 })

--- a/slice-guard/frontend/src/styles/main.css
+++ b/slice-guard/frontend/src/styles/main.css
@@ -10,20 +10,56 @@
   }
 }
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
+  /*
+  * Custom branding colors
+  */
+
+  --color-salem-50: #ecfff5;
+  --color-salem-100: #d3ffe8;
+  --color-salem-200: #aaffd3;
+  --color-salem-300: #69ffb2;
+  --color-salem-400: #21ff8a;
+  --color-salem-500: #00f268;
+  --color-salem-600: #00ca53;
+  --color-salem-700: #009e44;
+  --color-salem-800: #007f3c;
+  --color-salem-900: #026532;
+  --color-salem-950: #003919;
+
+  --color-bird-flower-50: #fafcea;
+  --color-bird-flower-100: #f3f9c8;
+  --color-bird-flower-200: #ecf494;
+  --color-bird-flower-300: #e6ed57;
+  --color-bird-flower-400: #e5e629;
+  --color-bird-flower-500: #c7c11a;
+  --color-bird-flower-600: #b9a615;
+  --color-bird-flower-700: #937a15;
+  --color-bird-flower-800: #7a6019;
+  --color-bird-flower-900: #694f1a;
+  --color-bird-flower-950: #3d2b0b;
+
+  /*
+  * Surface colors
+  */
+  --color-surface-lowest: #fffdfc;
+  --color-surface-low: #f8f7f5;
+  --color-surface: #f2f2f7;
+  --color-surface-high: #e5e5ea;
+  --color-surface-highest: #d1d1d6;
+
   /* Light theme inspired by Apple's palette */
-  --color-background: oklch(96.7% 0.003 264.542);
-  --color-foreground: oklch(98.5% 0.002 247.839);
-  --color-muted: #6e6e73;
-  --color-border: #c7c7d1;
-  --color-main: #007f3c; /* lighter British Racing Green */
-  --color-accent: #30d158; /* modern accent */
-  --color-accent-text: #000000; /* accent text is black */
-  --color-success: #34c759;
-  --color-warning: #ff9f0a;
-  --color-error: #ff3b30;
-  --color-info: #5ac8fa;
   --color-gray-1: oklch(98.4% 0.003 247.858);
   --color-gray-2: oklch(92.9% 0.013 255.508);
   --color-gray-3: oklch(86.9% 0.022 252.894);
+}
+
+.dark {
+  --color-surface-lowest: #000000;
+  --color-surface-low: #1c1c1e;
+  --color-surface: #2c2c2e;
+  --color-surface-high: #3a3a3c;
+  --color-surface-highest: #48484a;
 }

--- a/slice-guard/frontend/src/styles/main.css
+++ b/slice-guard/frontend/src/styles/main.css
@@ -50,16 +50,34 @@
   --color-surface-high: #e5e5ea;
   --color-surface-highest: #d1d1d6;
 
-  /* Light theme inspired by Apple's palette */
-  --color-gray-1: oklch(98.4% 0.003 247.858);
-  --color-gray-2: oklch(92.9% 0.013 255.508);
-  --color-gray-3: oklch(86.9% 0.022 252.894);
+  /**
+  * Text colors
+  */
+  --color-fg-primary: #000000ff;
+  --color-fg-secondary: #3c3c4399;
+  --color-fg-tertiary: #3c3c434c;
+  --color-fg-quaternary: #3c3c432d;
+  --color-fg-inverse: #ffffffe6;
+  --color-fg-accent: #007aff;
 }
 
 .dark {
+  /*
+  * Dark theme surface colors
+  */
   --color-surface-lowest: #000000;
   --color-surface-low: #1c1c1e;
   --color-surface: #2c2c2e;
   --color-surface-high: #3a3a3c;
   --color-surface-highest: #48484a;
+
+  /*
+  * Dark theme text colors
+  */
+  --color-fg-primary: #ffffffff;
+  --color-fg-secondary: #ebebf599;
+  --color-fg-tertiary: #ebebf54c;
+  --color-fg-quaternary: #ebebf52d;
+  --color-fg-inverse: #000000e6;
+  --color-fg-accent: #0a84ff;
 }

--- a/slice-guard/frontend/src/views/CreateLabView.vue
+++ b/slice-guard/frontend/src/views/CreateLabView.vue
@@ -30,14 +30,16 @@ async function submit() {
 <template>
   <div class="min-h-screen flex flex-col items-center justify-start bg-surface-lowest text-white">
     <h1 class="text-3xl font-semibold mt-10 mb-6 text-black">Create a Lab</h1>
-    <form @submit.prevent="submit" class="flex flex-col gap-3 w-full max-w-md text-sm text-gray-400">
+
+    <form @submit.prevent="submit" class="flex flex-col gap-3 w-full max-w-md text-sm">
       <input v-model="name" type="text" placeholder="Name" required
-        class="bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
+        class="bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800 placeholder-fg-secondary" />
       <input v-model="description" type="text" placeholder="Description"
-        class="bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
+        class="bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800 placeholder-fg-secondary" />
       <input v-model="imageUrl" type="url" placeholder="Image URL"
-        class="bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
+        class="bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800 placeholder-fg-secondary" />
       <p v-if="error" class="text-red-600 px-1">{{ error }}</p>
+
       <Button variant="primary" class="mt-2 py-2">Create Lab</Button>
     </form>
   </div>

--- a/slice-guard/frontend/src/views/CreateLabView.vue
+++ b/slice-guard/frontend/src/views/CreateLabView.vue
@@ -28,15 +28,15 @@ async function submit() {
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col items-center justify-start bg-background text-foreground">
+  <div class="min-h-screen flex flex-col items-center justify-start bg-surface-lowest text-white">
     <h1 class="text-3xl font-semibold mt-10 mb-6 text-black">Create a Lab</h1>
     <form @submit.prevent="submit" class="flex flex-col gap-3 w-full max-w-md text-sm text-gray-400">
       <input v-model="name" type="text" placeholder="Name" required
-        class="bg-foreground shadow-md py-3 px-5 rounded-xl w-full focus:outline-main" />
+        class="bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
       <input v-model="description" type="text" placeholder="Description"
-        class="bg-foreground shadow-md py-3 px-5 rounded-xl w-full focus:outline-main" />
+        class="bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
       <input v-model="imageUrl" type="url" placeholder="Image URL"
-        class="bg-foreground shadow-md py-3 px-5 rounded-xl w-full focus:outline-main" />
+        class="bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
       <p v-if="error" class="text-red-600 px-1">{{ error }}</p>
       <Button variant="primary" class="mt-2 py-2">Create Lab</Button>
     </form>

--- a/slice-guard/frontend/src/views/NoLabsView.vue
+++ b/slice-guard/frontend/src/views/NoLabsView.vue
@@ -5,7 +5,7 @@ const router = useRouter();
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col items-center justify-center bg-background text-foreground">
+  <div class="min-h-screen flex flex-col items-center justify-center bg-surface-lowest text-white">
     <h1 class="text-3xl font-semibold mb-4 text-black">Welcome to Slice Guard</h1>
     <p class="text-gray-500 mb-6">You are not a member of any labs yet.</p>
     <Button variant="primary" @click="router.push('/lab/create')">Create a Lab</Button>

--- a/slice-guard/frontend/src/views/NoLabsView.vue
+++ b/slice-guard/frontend/src/views/NoLabsView.vue
@@ -7,7 +7,7 @@ const router = useRouter();
 <template>
   <div class="min-h-screen flex flex-col items-center justify-center bg-surface-lowest text-white">
     <h1 class="text-3xl font-semibold mb-4 text-black">Welcome to Slice Guard</h1>
-    <p class="text-gray-500 mb-6">You are not a member of any labs yet.</p>
+    <p class="text-fg-secondary mb-6">You are not a member of any labs yet.</p>
     <Button variant="primary" @click="router.push('/lab/create')">Create a Lab</Button>
     <!-- ! TODO: Add a button here to join a lab -->
   </div>

--- a/slice-guard/frontend/src/views/RootRedirect.vue
+++ b/slice-guard/frontend/src/views/RootRedirect.vue
@@ -37,5 +37,5 @@ onMounted(async () => {
 
 <template>
   <!--TODO: Very silly loading screen needed-->
-  <div class="min-h-screen flex items-center justify-center bg-background text-foreground">Loading...</div>
+  <div class="min-h-screen flex items-center justify-center bg-surface-lowest text-white">Loading...</div>
 </template>

--- a/slice-guard/frontend/src/views/auth/LoginPage.vue
+++ b/slice-guard/frontend/src/views/auth/LoginPage.vue
@@ -22,22 +22,23 @@ async function submit() {
 
 <template>
   <div class="w-full bg-surface-low drop-shadow-sm py-3 px-5">
-    <p class="text-lg font-semibold text-start">Slice Guard</p>
+    <p class="text-lg font-semibold text-start text-fg-primary">Slice Guard</p>
   </div>
 
   <div class="flex flex-col items-center min-h-screen bg-surface-lowest gap-5">
     <div>
-      <h1 class="text-4xl font-semibold text-center mt-20">Hello again</h1>
-      <p class="text-sm text-gray-500 text-center mt-2">It's nice to see you :)</p>
+      <h1 class="text-fg-primary text-4xl font-semibold text-center mt-20">Hello again</h1>
+      <p class="text-sm text-fg-secondary text-center mt-2">It's nice to see you :)</p>
     </div>
 
     <form @submit.prevent="submit"
-      class="flex flex-col items-center justify-center w-full max-w-sm md:max-w-md gap-3 mt-10 text-sm text-gray-400">
+      class="flex flex-col items-center justify-center w-full max-w-sm md:max-w-md gap-3 mt-10 text-sm">
       <input v-model="email" type="email" placeholder="Email" required
-        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
+        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800 placeholder-fg-secondary" />
       <input v-model="password" type="password" placeholder="Password" required
-        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
+        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800 placeholder-fg-secondary" />
       <p v-if="error" class="text-red-600 text-sm w-full text-left px-1">{{ error }}</p>
+
       <div class="w-full">
         <Button variant="primary" class="col-span-2 mt-4 w-full py-2">Log In</Button>
         <Button variant="secondary" class="col-span-2 mt-2 w-full py-2" @click.prevent="router.push('/register')">Sign

--- a/slice-guard/frontend/src/views/auth/LoginPage.vue
+++ b/slice-guard/frontend/src/views/auth/LoginPage.vue
@@ -21,11 +21,11 @@ async function submit() {
 </script>
 
 <template>
-  <div class="w-full bg-foreground drop-shadow-sm py-3 px-5">
+  <div class="w-full bg-surface-low drop-shadow-sm py-3 px-5">
     <p class="text-lg font-semibold text-start">Slice Guard</p>
   </div>
 
-  <div class="flex flex-col items-center min-h-screen bg-background gap-5">
+  <div class="flex flex-col items-center min-h-screen bg-surface-lowest gap-5">
     <div>
       <h1 class="text-4xl font-semibold text-center mt-20">Hello again</h1>
       <p class="text-sm text-gray-500 text-center mt-2">It's nice to see you :)</p>
@@ -34,9 +34,9 @@ async function submit() {
     <form @submit.prevent="submit"
       class="flex flex-col items-center justify-center w-full max-w-sm md:max-w-md gap-3 mt-10 text-sm text-gray-400">
       <input v-model="email" type="email" placeholder="Email" required
-        class="col-span-2 bg-foreground shadow-md py-3 px-5 rounded-xl w-full focus:outline-main" />
+        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
       <input v-model="password" type="password" placeholder="Password" required
-        class="col-span-2 bg-foreground shadow-md py-3 px-5 rounded-xl w-full focus:outline-main" />
+        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
       <p v-if="error" class="text-red-600 text-sm w-full text-left px-1">{{ error }}</p>
       <div class="w-full">
         <Button variant="primary" class="col-span-2 mt-4 w-full py-2">Log In</Button>

--- a/slice-guard/frontend/src/views/auth/RegisterPage.vue
+++ b/slice-guard/frontend/src/views/auth/RegisterPage.vue
@@ -41,6 +41,7 @@ async function submit() {
       <input v-model="password" type="password" placeholder="Password" required
         class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
       <p v-if="error" class="text-red-600 text-sm w-full text-left px-1">{{ error }}</p>
+
       <div class="w-full">
         <Button variant="primary" class="col-span-2 mt-4 w-full py-2">Create Account</Button>
         <Button variant="secondary" class="col-span-2 mt-2 w-full py-2" @click.prevent="router.push('/login')">

--- a/slice-guard/frontend/src/views/auth/RegisterPage.vue
+++ b/slice-guard/frontend/src/views/auth/RegisterPage.vue
@@ -28,18 +28,19 @@ async function submit() {
 
   <div class="flex flex-col items-center min-h-screen bg-surface-lowest gap-5">
     <div>
-      <h1 class="text-4xl font-semibold text-center mt-20">Create your account</h1>
-      <p class="text-sm text-gray-500 text-center mt-2">Join us and start printing!</p>
+      <h1 class="text-fg-primary text-4xl font-semibold text-center mt-20">Create your account</h1>
+      <p class="text-sm text-fg-secondary text-center mt-2">Join us and start printing!</p>
     </div>
 
     <form @submit.prevent="submit"
-      class="flex flex-col items-center justify-center w-full max-w-sm md:max-w-md gap-3 mt-10 text-sm text-gray-400">
+      class="flex flex-col items-center justify-center w-full max-w-sm md:max-w-md gap-3 mt-10 text-sm">
+
       <input v-model="name" type="text" placeholder="Name" required
-        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
+        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800 placeholder-fg-secondary" />
       <input v-model="email" type="email" placeholder="Email" required
-        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
+        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800 placeholder-fg-secondary" />
       <input v-model="password" type="password" placeholder="Password" required
-        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
+        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800 placeholder-fg-secondary" />
       <p v-if="error" class="text-red-600 text-sm w-full text-left px-1">{{ error }}</p>
 
       <div class="w-full">

--- a/slice-guard/frontend/src/views/auth/RegisterPage.vue
+++ b/slice-guard/frontend/src/views/auth/RegisterPage.vue
@@ -22,11 +22,11 @@ async function submit() {
 </script>
 
 <template>
-  <div class="w-full bg-foreground drop-shadow-sm py-3 px-5">
+  <div class="w-full bg-surface-low drop-shadow-sm py-3 px-5">
     <p class="text-lg font-semibold text-start">Slice Guard</p>
   </div>
 
-  <div class="flex flex-col items-center min-h-screen bg-background gap-5">
+  <div class="flex flex-col items-center min-h-screen bg-surface-lowest gap-5">
     <div>
       <h1 class="text-4xl font-semibold text-center mt-20">Create your account</h1>
       <p class="text-sm text-gray-500 text-center mt-2">Join us and start printing!</p>
@@ -35,11 +35,11 @@ async function submit() {
     <form @submit.prevent="submit"
       class="flex flex-col items-center justify-center w-full max-w-sm md:max-w-md gap-3 mt-10 text-sm text-gray-400">
       <input v-model="name" type="text" placeholder="Name" required
-        class="col-span-2 bg-foreground shadow-md py-3 px-5 rounded-xl w-full focus:outline-main" />
+        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
       <input v-model="email" type="email" placeholder="Email" required
-        class="col-span-2 bg-foreground shadow-md py-3 px-5 rounded-xl w-full focus:outline-main" />
+        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
       <input v-model="password" type="password" placeholder="Password" required
-        class="col-span-2 bg-foreground shadow-md py-3 px-5 rounded-xl w-full focus:outline-main" />
+        class="col-span-2 bg-surface-low shadow-md py-3 px-5 rounded-xl w-full focus:outline-salem-800" />
       <p v-if="error" class="text-red-600 text-sm w-full text-left px-1">{{ error }}</p>
       <div class="w-full">
         <Button variant="primary" class="col-span-2 mt-4 w-full py-2">Create Account</Button>

--- a/slice-guard/frontend/src/views/lab/LabDashboard.vue
+++ b/slice-guard/frontend/src/views/lab/LabDashboard.vue
@@ -1,20 +1,29 @@
 <script setup lang="ts">
+import ThemeToggle from '../../components/ThemeToggle.vue';
+
 interface Props {
-  lab: any | null
-  error: string
-  loading: boolean
+    lab: any | null
+    error: string
+    loading: boolean
 }
 
 defineProps<Props>()
+
+
+
 </script>
 
 <template>
     <div class="space-y-4">
         <div v-if="error" class="text-red-600">{{ error }}</div>
         <div v-if="lab">
-            <h1 class="text-2xl font-semibold">{{ lab.name }}</h1>
-            <p v-if="lab.description" class="text-gray-500">{{ lab.description }}</p>
+            <h1 class="text-fg-primary text-2xl font-semibold">{{ lab.name }}</h1>
+            <p v-if="lab.description" class="text-fg-secondary">{{ lab.description }}</p>
         </div>
-        <div v-else-if="loading" class="text-gray-500">Loading...</div>
+        <div v-else-if="loading" class="text-fg-secondary">Loading...</div>
     </div>
+
+    <!-- Theme Toggle Button -->
+    <ThemeToggle class="mt-4" variant="secondary" />
+
 </template>

--- a/slice-guard/frontend/src/views/lab/LabLayout.vue
+++ b/slice-guard/frontend/src/views/lab/LabLayout.vue
@@ -49,10 +49,10 @@ watch(() => route.params.id, fetchLab)
       <!--User list for lab layout-->
       <!--! TODO: This does not resize and rather the main content does - make this collapse later down the road when I'm not so lazy.
             -->
-      <div class="h-full bg-background p-4 min-w-52 max-w-60">
-        <!-- User list for the lab layout -->
-        <LabUserList />
-      </div>
+        <div class="h-full bg-background p-4 min-w-52 max-w-60">
+          <!-- User list for the lab layout -->
+          <LabUserList :lab="lab" />
+        </div>
     </div>
   </div>
 </template>

--- a/slice-guard/frontend/src/views/lab/LabLayout.vue
+++ b/slice-guard/frontend/src/views/lab/LabLayout.vue
@@ -4,8 +4,7 @@ import { useRoute } from 'vue-router'
 import Sidebar from './Sidebar.vue'
 import LabUserList from './LabUserList.vue'
 import { authorizedFetch } from '../../services/auth'
-import { ws } from '../../services/ws'
-import { Lab } from '@shared/db/lab';
+import { type Lab } from '@shared/db/lab';
 
 const route = useRoute()
 
@@ -33,14 +32,14 @@ watch(() => route.params.id, fetchLab)
 </script>
 
 <template>
-  <div class="flex min-h-screen bg-background">
-    <!-- Sidebar has no background and takes on that of the main -->
-    <aside class="w-56 lg:w-64 xl:w-72 bg-background min-h-screen p-7 shrink-0">
+  <div class="flex min-h-screen bg-surface-lowest">
+    <aside
+      class="w-56 lg:w-64 xl:w-72 bg-surface-low min-h-screen p-7 shrink-0 rounded-r-4xl shadow-inner shadow-surface-high">
       <Sidebar :lab="lab" />
     </aside>
 
     <!-- Main content area -->
-    <div class="rounded-l-5xl bg-foreground w-full drop-shadow-lg flex gap-0">
+    <div class="bg-surface-lowest w-full flex gap-0">
       <div class="p-6 flex-1 w-full">
         <!-- Actual insert content-->
         <router-view :lab="lab" :error="error" :loading="loading" />
@@ -49,10 +48,10 @@ watch(() => route.params.id, fetchLab)
       <!--User list for lab layout-->
       <!--! TODO: This does not resize and rather the main content does - make this collapse later down the road when I'm not so lazy.
             -->
-        <div class="h-full bg-background p-4 min-w-52 max-w-60">
-          <!-- User list for the lab layout -->
-          <LabUserList :lab="lab" />
-        </div>
+      <div class="h-full bg-surface-lowest p-4 min-w-60 max-w-80 overflow-y-scroll no-scrollbar">
+        <!-- User list for the lab layout -->
+        <LabUserList :lab="lab" />
+      </div>
     </div>
   </div>
 </template>

--- a/slice-guard/frontend/src/views/lab/LabPrintRequests.vue
+++ b/slice-guard/frontend/src/views/lab/LabPrintRequests.vue
@@ -2,7 +2,7 @@
 </script>
 
 <template>
-    <div>
+    <div class="text-fg-primary">
         I am the Lab Print Requests page.
     </div>
 </template>

--- a/slice-guard/frontend/src/views/lab/LabPrintRequests.vue
+++ b/slice-guard/frontend/src/views/lab/LabPrintRequests.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+</script>
+
+<template>
+    <div>
+        I am the Lab Print Requests page.
+    </div>
+</template>

--- a/slice-guard/frontend/src/views/lab/LabUserList.vue
+++ b/slice-guard/frontend/src/views/lab/LabUserList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, watch } from 'vue'
-import type { Lab, LabRole, LabMember } from '@shared/db/lab'
+import type { Lab, LabMember } from '@shared/db/lab'
 import type { User } from '@shared/db/user'
 import { authorizedFetch } from '../../services/auth'
 
@@ -36,7 +36,7 @@ watch(() => props.lab?.id, fetchMembers)
 <template>
     <div class="flex flex-col gap-4">
         <!-- Placeholder for search bar of users -->
-        <div class="w-full bg-foreground shadow-md rounded-lg py-2 px-4 flex items-center justify-end">
+        <div class="w-full bg-surface-low shadow-md rounded-lg py-2 px-4 flex items-center justify-end">
             <!-- Magnifying glass SVG -->
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-gray-500" fill="none" viewBox="0 0 24 24"
                 stroke="currentColor">

--- a/slice-guard/frontend/src/views/lab/LabUserList.vue
+++ b/slice-guard/frontend/src/views/lab/LabUserList.vue
@@ -1,14 +1,36 @@
 <script setup lang="ts">
-import { Lab } from '@shared/db/lab'
+import { ref, onMounted, watch } from 'vue'
+import type { Lab, LabRole, LabMember } from '@shared/db/lab'
+import type { User } from '@shared/db/user'
+import { authorizedFetch } from '../../services/auth'
 
-// When the value of the lab changes to null (or the lab instance changes), we want to re-fetch the users
 const props = defineProps<{
     lab: Lab | null
-}>();
+}>()
 
-// Mapping of {top level role: {id, name}[]};
-// TODO: Fetch the members** from the API (lab member object that also includes a list of their complete roles (sorted top down), permissions, etc.)
-const members = ref<{ [key: string]: { id: number, name: string }[] }>({});
+interface MemberResponse {
+    member: LabMember
+    user: User
+}
+
+const members = ref<Record<string, { id: number; name: string }[]>>({})
+
+async function fetchMembers() {
+    if (!props.lab) return
+    const res = await authorizedFetch(`/labs/${props.lab.id}/members`)
+    if (!res.ok) return
+    const data = (await res.json()) as MemberResponse[]
+    const map: Record<string, { id: number; name: string }[]> = {}
+    for (const item of data) {
+        const category = item.member.roles[0]?.name ?? 'Member'
+        if (!map[category]) map[category] = []
+        map[category].push({ id: item.user.id, name: item.user.name ?? item.user.email })
+    }
+    members.value = map
+}
+
+onMounted(fetchMembers)
+watch(() => props.lab?.id, fetchMembers)
 </script>
 
 <template>
@@ -22,8 +44,8 @@ const members = ref<{ [key: string]: { id: number, name: string }[] }>({});
                     d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
             </svg>
         </div>
-        <!-- Display the list of users to use the variable -->
-        <div v-for="(users, category) in randomUsers" :key="category" class="flex flex-col gap-2">
+        <!-- Display the list of users categorized by role -->
+        <div v-for="(users, category) in members" :key="category" class="flex flex-col gap-2">
             <!-- Category header -->
             <h3 class="text-xs font-medium text-gray-500 uppercase tracking-wide px-2">
                 {{ category }}

--- a/slice-guard/frontend/src/views/lab/LabUserList.vue
+++ b/slice-guard/frontend/src/views/lab/LabUserList.vue
@@ -47,7 +47,7 @@ watch(() => props.lab?.id, fetchMembers)
         <!-- Display the list of users categorized by role -->
         <div v-for="(users, category) in members" :key="category" class="flex flex-col gap-2">
             <!-- Category header -->
-            <h3 class="text-xs font-medium text-gray-500 uppercase tracking-wide px-2">
+            <h3 class="text-xs font-medium text-fg-primary uppercase tracking-wide px-2">
                 {{ category }}
             </h3>
 
@@ -55,9 +55,9 @@ watch(() => props.lab?.id, fetchMembers)
             <ul class="space-y-1">
                 <li v-for="user in users" :key="user.id">
                     <div
-                        class="flex items-center justify-start gap-3 p-2 rounded-xl hover:shadow-md transition-all duration-200 hover:text-black text-gray-600">
+                        class="flex items-center justify-start gap-3 p-2 rounded-xl hover:shadow-md transition-all duration-200 hover:text-black text-fg-primary">
                         <!-- Placeholder user avatar -->
-                        <div class="w-7 h-7 rounded-full bg-gray-500 flex-none"></div>
+                        <div class="w-7 h-7 rounded-full bg-gray-700 flex-none"></div>
 
                         <span class="text-sm truncate">
                             {{ user.name }}
@@ -67,7 +67,7 @@ watch(() => props.lab?.id, fetchMembers)
             </ul>
 
             <!-- Divider line -->
-            <hr class="border-gray-200 my-2">
+            <hr class="border-surface-high my-2">
 
         </div>
     </div>

--- a/slice-guard/frontend/src/views/lab/Sidebar.vue
+++ b/slice-guard/frontend/src/views/lab/Sidebar.vue
@@ -9,6 +9,12 @@ const auth = useAuthStore()
 const route = useRoute()
 const labId = computed(() => route.params.id)
 
+function navClasses(name: string) {
+    const base =
+        'text-sm text-gray-800 hover:text-black hover:text-pretty rounded-lg w-full transition-all duration-250 py-1 px-4 hover:shadow-md hover:font-medium'
+    return route.name === name ? base + ' bg-gray-100' : base
+}
+
 const props = defineProps<{
     lab: Lab | null
 }>();
@@ -42,12 +48,10 @@ const props = defineProps<{
 
             <!-- Navigation links (need gear icon at the right side of each later on) -->
             <nav class="flex flex-col space-y-1">
-                <RouterLink :to="`/lab/${labId}/dashboard`"
-                    class="text-sm text-gray-800 hover:text-black hover:text-pretty rounded-lg w-full transition-all duration-250 py-1 px-4 hover:shadow-md hover:font-medium">
+                <RouterLink :to="{ name: 'LabDashboard', params: { id: labId } }" :class="navClasses('LabDashboard')">
                     dashboard</RouterLink>
 
-                <RouterLink :to="`/lab/${labId}/print-requests`"
-                    class="text-sm text-gray-800 hover:text-black hover:text-pretty rounded-lg w-full transition-all duration-250 py-1 px-4 hover:shadow-md hover:font-medium">
+                <RouterLink :to="`/lab/${labId}/print-requests`" :class="navClasses('PrintRequests')">
                     print-requests</RouterLink>
             </nav>
         </div>

--- a/slice-guard/frontend/src/views/lab/Sidebar.vue
+++ b/slice-guard/frontend/src/views/lab/Sidebar.vue
@@ -10,7 +10,7 @@ const route = useRoute()
 const labId = computed(() => route.params.id)
 
 const navClass = ref(
-    'text-sm text-gray-800 hover:text-black hover:text-pretty rounded-lg w-full transition-all duration-250 py-1 px-4 hover:shadow-md'
+    'text-sm text-fg-primary hover:text-pretty rounded-lg w-full transition-all duration-250 py-1 px-4 hover:shadow-md'
 )
 
 const navIsActive = (name: string) => {
@@ -18,7 +18,7 @@ const navIsActive = (name: string) => {
 }
 
 const isActiveClass = ref(
-    'bg-surface-high text-black shadow-md font-medium'
+    'shadow-md'
 )
 
 const props = defineProps<{
@@ -31,22 +31,22 @@ const props = defineProps<{
     <div class="flex flex-col gap-5 h-full justify-items-start">
         <!--Currently active lab information (and way to change lab)-->
         <div class="text-left flex flex-col items-start gap-2">
-            <h1 class="text-lg/5 font-semibold text-pretty">{{ props.lab?.name }}</h1>
-            <p class="text-xs text-gray-500 line-clamp-2">{{ props.lab?.description }}</p>
+            <h1 class="text-lg/5 text-fg-primary font-semibold text-pretty">{{ props.lab?.name }}</h1>
+            <p class="text-xs text-fg-secondary line-clamp-2">{{ props.lab?.description }}</p>
         </div>
 
 
         <!-- Divider line -->
-        <hr class="border-gray-400">
+        <hr class="border-fg-secondary">
 
         <!-- Navigation for the selected Lab -->
         <div>
             <!-- Similar to Discord style, has stats information and channels, each separated by a divider -->
             <div class="flex flex-row justify-between items-center">
-                <h2 class="text-sm font-medium text-gray-500 mb-2 uppercase">Lab Center</h2>
+                <h2 class="text-sm font-medium text-fg-primary mb-2 uppercase">Lab Center</h2>
 
                 <!-- Dropdown arrow to collapse category -->
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 cursor-pointer" fill="none"
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-fg-secondary cursor-pointer" fill="none"
                     viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
                 </svg>
@@ -70,7 +70,7 @@ const props = defineProps<{
         <div>
             <!-- Similar to Discord style, has stats information and channels, each separated by a divider -->
             <div class=" flex flex-row justify-between items-center">
-                <h2 class="text-sm font-medium text-gray-500 mb-2 uppercase">Channels</h2>
+                <h2 class="text-sm font-medium text-fg-primary mb-2 uppercase">Channels</h2>
 
                 <!-- Dropdown arrow to collapse category -->
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 cursor-pointer" fill="none"
@@ -81,11 +81,9 @@ const props = defineProps<{
 
             <!-- Navigation links (need gear icon at the right side of each later on) -->
             <nav class="flex flex-col space-y-1">
-                <a href="#"
-                    class="text-sm text-gray-800 hover:text-black hover:text-pretty rounded-lg w-full transition-all duration-250 py-1 px-4 hover:shadow-md hover:font-medium">general</a>
+                <a href="#" :class="navClass">general</a>
 
-                <a href="#"
-                    class="text-sm text-gray-800 hover:text-black hover:text-pretty rounded-lg w-full transition-all duration-250 py-1 px-4 hover:shadow-md hover:font-medium">some-private-channel</a>
+                <a href="#" :class="navClass">some-private-channel</a>
             </nav>
         </div>
 
@@ -94,7 +92,7 @@ const props = defineProps<{
         <!-- Avatar information -->
 
         <!-- Divider line for avatar -->
-        <hr class="border-gray-400 mt-auto">
+        <hr class="border-fg-secondary mt-auto">
 
         <div class="flex flex-row gap-2 rounded-xl justify-start items-center">
             <!-- Temporary avatar image that takes up the same height as the text it's to the left of -->
@@ -102,11 +100,11 @@ const props = defineProps<{
             </div>
 
             <div>
-                <h2 class="text-sm font-semibold">{{ auth.user?.name ?? 'Unknown User' }}</h2>
+                <h2 class="text-fg-primary text-sm font-semibold">{{ auth.user?.name ?? 'Unknown User' }}</h2>
             </div>
 
             <!--Settings gear icon at the end of the flex -->
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 cursor-pointer ml-auto" fill="none"
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-fg-secondary cursor-pointer ml-auto" fill="none"
                 viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m-6 0l3-3V8" />
             </svg>

--- a/slice-guard/frontend/src/views/lab/Sidebar.vue
+++ b/slice-guard/frontend/src/views/lab/Sidebar.vue
@@ -1,19 +1,25 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { useAuthStore } from '../../store/auth'
-import { Lab } from '@shared/db/lab'
+import { type Lab } from '@shared/db/lab'
 
 const auth = useAuthStore()
 
 const route = useRoute()
 const labId = computed(() => route.params.id)
 
-function navClasses(name: string) {
-    const base =
-        'text-sm text-gray-800 hover:text-black hover:text-pretty rounded-lg w-full transition-all duration-250 py-1 px-4 hover:shadow-md hover:font-medium'
-    return route.name === name ? base + ' bg-gray-100' : base
+const navClass = ref(
+    'text-sm text-gray-800 hover:text-black hover:text-pretty rounded-lg w-full transition-all duration-250 py-1 px-4 hover:shadow-md'
+)
+
+const navIsActive = (name: string) => {
+    return route.name === name
 }
+
+const isActiveClass = ref(
+    'bg-surface-high text-black shadow-md font-medium'
+)
 
 const props = defineProps<{
     lab: Lab | null
@@ -48,18 +54,22 @@ const props = defineProps<{
 
             <!-- Navigation links (need gear icon at the right side of each later on) -->
             <nav class="flex flex-col space-y-1">
-                <RouterLink :to="{ name: 'LabDashboard', params: { id: labId } }" :class="navClasses('LabDashboard')">
-                    dashboard</RouterLink>
+                <RouterLink :to="{ name: 'LabDashboard', params: { id: labId } }"
+                    :class="[navIsActive('LabDashboard') ? isActiveClass : '', navClass]">
+                    dashboard
+                </RouterLink>
 
-                <RouterLink :to="`/lab/${labId}/print-requests`" :class="navClasses('PrintRequests')">
-                    print-requests</RouterLink>
+                <RouterLink :to="`/lab/${labId}/print-requests`"
+                    :class="[navIsActive('LabPrintRequests') ? isActiveClass : '', navClass]">
+                    print-requests
+                </RouterLink>
             </nav>
         </div>
 
         <!-- Navigation for Lab text channels - very similar to the above should be made into a dynamic system soon -->
         <div>
             <!-- Similar to Discord style, has stats information and channels, each separated by a divider -->
-            <div class="flex flex-row justify-between items-center">
+            <div class=" flex flex-row justify-between items-center">
                 <h2 class="text-sm font-medium text-gray-500 mb-2 uppercase">Channels</h2>
 
                 <!-- Dropdown arrow to collapse category -->

--- a/slice-guard/frontend/tailwind.config.cjs
+++ b/slice-guard/frontend/tailwind.config.cjs
@@ -4,20 +4,7 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        background: 'var(--color-background)',
-        foreground: 'var(--color-foreground)',
-        muted: 'var(--color-muted)',
-        border: 'var(--color-border)',
-        main: 'var(--color-main)',
-        accent: 'var(--color-accent)',
-        'accent-text': 'var(--color-accent-text)',
-        success: 'var(--color-success)',
-        warning: 'var(--color-warning)',
-        error: 'var(--color-error)',
-        info: 'var(--color-info)',
-        "gray-1": 'var(--color-gray-1)',
-        "gray-2": 'var(--color-gray-2)',
-        "gray-3": 'var(--color-gray-3)',
+
       }
     }
   },

--- a/slice-guard/shared/db/lab.ts
+++ b/slice-guard/shared/db/lab.ts
@@ -4,6 +4,11 @@ export interface Lab {
     name: string;
     description?: string | null;
     image_url?: string | null;
+    /**
+     * Identifier of the default role that all members receive when joining
+     * this lab.
+     */
+    default_role_id?: number | null;
     created_at: Date;
 }
 
@@ -18,7 +23,11 @@ export interface LabRole {
 export interface LabMember {
     lab_id: number;
     user_id: number;
-    role_id?: number | null;
+    /**
+     * Full list of roles this member has ordered from highest to lowest
+     * hierarchy. An empty array means the member has no explicit roles.
+     */
+    roles: LabRole[];
     joined_at: Date;
 }
 


### PR DESCRIPTION
## Summary
- track default role on `Lab` and include role objects for members
- migrate members table to many-to-many `member_roles`
- update DB helpers, HTTP routes and sidebar UI for new role structure
- adjust tests for revised queries

## Testing
- `bun --cwd slice-guard/backend test`

------
https://chatgpt.com/codex/tasks/task_e_686023e13d108320a202a5830ef4289e