### PR TITLE
Implement lab route refactor and request list filters

### DIFF
--- a/slice-guard/backend/migrations/006_request_state.sql
+++ b/slice-guard/backend/migrations/006_request_state.sql
@@ -1,0 +1,1 @@
+ALTER TABLE lab.print_requests ADD COLUMN is_closed BOOLEAN NOT NULL DEFAULT FALSE;

--- a/slice-guard/backend/migrations/007_request_file_data.sql
+++ b/slice-guard/backend/migrations/007_request_file_data.sql
@@ -1,0 +1,4 @@
+ALTER TABLE lab.print_requests
+    ADD COLUMN file_data BYTEA NOT NULL DEFAULT ''::bytea;
+ALTER TABLE lab.print_requests
+    DROP COLUMN file_path;

--- a/slice-guard/backend/src/db/lab.ts
+++ b/slice-guard/backend/src/db/lab.ts
@@ -149,6 +149,11 @@ export async function getMemberRolePermissions(
     labId: number,
     userId: number
 ): Promise<number | null> {
+    const owners: { owner_id: number }[] = await db`
+        SELECT owner_id FROM lab.labs WHERE id = ${labId}
+    `;
+    if (!owners[0]) return null;
+    if (Number(owners[0].owner_id) === userId) return LabPermission.ALL;
     const rows: { permissions: number }[] = await db`
         SELECT r.permissions
           FROM lab.member_roles mr

--- a/slice-guard/backend/src/db/request.ts
+++ b/slice-guard/backend/src/db/request.ts
@@ -25,14 +25,14 @@ export async function createPrintRequest(
     db: SQL,
     labId: number,
     userId: number,
-    filePath: string,
+    fileData: Buffer,
     metadata: unknown,
     description: string | null = null,
 ): Promise<PrintRequestRow> {
     const rows: PrintRequestRow[] = await db`
-        INSERT INTO lab.print_requests (lab_id, user_id, file_path, metadata, description)
-             VALUES (${labId}, ${userId}, ${filePath}, ${JSON.stringify(metadata)}, ${description})
-        RETURNING id, lab_id, user_id, file_path, metadata, description, is_closed, created_at
+        INSERT INTO lab.print_requests (lab_id, user_id, file_data, metadata, description)
+             VALUES (${labId}, ${userId}, ${fileData}, ${JSON.stringify(metadata)}, ${description})
+        RETURNING id, lab_id, user_id, file_data, metadata, description, is_closed, created_at
     `;
     return normalizeRequest(rows[0]);
 }
@@ -43,7 +43,7 @@ export async function getUserPrintRequests(
     userId: number
 ): Promise<PrintRequestRow[]> {
     const rows: PrintRequestRow[] = await db`
-        SELECT id, lab_id, user_id, file_path, metadata, description, is_closed, created_at
+        SELECT id, lab_id, user_id, file_data, metadata, description, is_closed, created_at
           FROM lab.print_requests
          WHERE lab_id = ${labId} AND user_id = ${userId}
     `;
@@ -119,7 +119,7 @@ export async function getAllPrintRequests(
     labId: number,
 ): Promise<PrintRequestRow[]> {
     const rows: PrintRequestRow[] = await db`
-        SELECT id, lab_id, user_id, file_path, metadata, description, is_closed, created_at
+        SELECT id, lab_id, user_id, file_data, metadata, description, is_closed, created_at
           FROM lab.print_requests
          WHERE lab_id = ${labId}
     `;
@@ -143,7 +143,7 @@ export async function getPrintRequestById(
     requestId: number,
 ): Promise<PrintRequestRow | null> {
     const rows: PrintRequestRow[] = await db`
-        SELECT id, lab_id, user_id, file_path, metadata, description, is_closed, created_at
+        SELECT id, lab_id, user_id, file_data, metadata, description, is_closed, created_at
           FROM lab.print_requests
          WHERE id = ${requestId}
     `;
@@ -159,7 +159,7 @@ export async function setRequestClosed(
         UPDATE lab.print_requests
            SET is_closed = ${isClosed}
          WHERE id = ${requestId}
-        RETURNING id, lab_id, user_id, file_path, metadata, description, is_closed, created_at
+        RETURNING id, lab_id, user_id, file_data, metadata, description, is_closed, created_at
     `;
     return normalizeRequest(rows[0]);
 }

--- a/slice-guard/backend/src/db/request.ts
+++ b/slice-guard/backend/src/db/request.ts
@@ -15,7 +15,7 @@ export async function createPrintRequest(
     const rows: PrintRequestRow[] = await db`
         INSERT INTO lab.print_requests (lab_id, user_id, file_path, metadata, description)
              VALUES (${labId}, ${userId}, ${filePath}, ${JSON.stringify(metadata)}, ${description})
-        RETURNING id, lab_id, user_id, file_path, metadata, description, created_at
+        RETURNING id, lab_id, user_id, file_path, metadata, description, is_closed, created_at
     `;
     return rows[0];
 }
@@ -26,7 +26,7 @@ export async function getUserPrintRequests(
     userId: number
 ): Promise<PrintRequestRow[]> {
     const rows: PrintRequestRow[] = await db`
-        SELECT id, lab_id, user_id, file_path, metadata, description, created_at
+        SELECT id, lab_id, user_id, file_path, metadata, description, is_closed, created_at
           FROM lab.print_requests
          WHERE lab_id = ${labId} AND user_id = ${userId}
     `;
@@ -102,7 +102,7 @@ export async function getAllPrintRequests(
     labId: number,
 ): Promise<PrintRequestRow[]> {
     const rows: PrintRequestRow[] = await db`
-        SELECT id, lab_id, user_id, file_path, metadata, description, created_at
+        SELECT id, lab_id, user_id, file_path, metadata, description, is_closed, created_at
           FROM lab.print_requests
          WHERE lab_id = ${labId}
     `;
@@ -119,4 +119,30 @@ export async function listTags(
          WHERE lab_id = ${labId}
     `;
     return rows;
+}
+
+export async function getPrintRequestById(
+    db: SQL,
+    requestId: number,
+): Promise<PrintRequestRow | null> {
+    const rows: PrintRequestRow[] = await db`
+        SELECT id, lab_id, user_id, file_path, metadata, description, is_closed, created_at
+          FROM lab.print_requests
+         WHERE id = ${requestId}
+    `;
+    return rows[0] ?? null;
+}
+
+export async function setRequestClosed(
+    db: SQL,
+    requestId: number,
+    isClosed: boolean,
+): Promise<PrintRequestRow> {
+    const rows: PrintRequestRow[] = await db`
+        UPDATE lab.print_requests
+           SET is_closed = ${isClosed}
+         WHERE id = ${requestId}
+        RETURNING id, lab_id, user_id, file_path, metadata, description, is_closed, created_at
+    `;
+    return rows[0];
 }

--- a/slice-guard/backend/src/db/request.ts
+++ b/slice-guard/backend/src/db/request.ts
@@ -96,3 +96,27 @@ export async function getTagsForRequest(
     `;
     return rows;
 }
+
+export async function getAllPrintRequests(
+    db: SQL,
+    labId: number,
+): Promise<PrintRequestRow[]> {
+    const rows: PrintRequestRow[] = await db`
+        SELECT id, lab_id, user_id, file_path, metadata, description, created_at
+          FROM lab.print_requests
+         WHERE lab_id = ${labId}
+    `;
+    return rows;
+}
+
+export async function listTags(
+    db: SQL,
+    labId: number,
+): Promise<RequestTagRow[]> {
+    const rows: RequestTagRow[] = await db`
+        SELECT id, lab_id, name, is_default, created_at
+          FROM lab.request_tags
+         WHERE lab_id = ${labId}
+    `;
+    return rows;
+}

--- a/slice-guard/backend/src/db/request.ts
+++ b/slice-guard/backend/src/db/request.ts
@@ -4,6 +4,23 @@ import type { SQL } from "bun";
 export interface PrintRequestRow extends PrintRequest { }
 export interface RequestTagRow extends RequestTag { }
 
+function normalizeRequest(row: PrintRequestRow): PrintRequestRow {
+    return {
+        ...row,
+        id: Number(row.id),
+        lab_id: Number(row.lab_id),
+        user_id: Number(row.user_id),
+    };
+}
+
+function normalizeTag(row: RequestTagRow): RequestTagRow {
+    return {
+        ...row,
+        id: Number(row.id),
+        lab_id: Number(row.lab_id),
+    };
+}
+
 export async function createPrintRequest(
     db: SQL,
     labId: number,
@@ -17,7 +34,7 @@ export async function createPrintRequest(
              VALUES (${labId}, ${userId}, ${filePath}, ${JSON.stringify(metadata)}, ${description})
         RETURNING id, lab_id, user_id, file_path, metadata, description, is_closed, created_at
     `;
-    return rows[0];
+    return normalizeRequest(rows[0]);
 }
 
 export async function getUserPrintRequests(
@@ -30,7 +47,7 @@ export async function getUserPrintRequests(
           FROM lab.print_requests
          WHERE lab_id = ${labId} AND user_id = ${userId}
     `;
-    return rows;
+    return rows.map(normalizeRequest);
 }
 
 export async function createTag(
@@ -44,7 +61,7 @@ export async function createTag(
              VALUES (${labId}, ${name}, ${isDefault})
         RETURNING id, lab_id, name, is_default, created_at
     `;
-    return rows[0];
+    return normalizeTag(rows[0]);
 }
 
 export async function setTagDefault(
@@ -58,7 +75,7 @@ export async function setTagDefault(
          WHERE id = ${tagId}
         RETURNING id, lab_id, name, is_default, created_at
     `;
-    return rows[0];
+    return normalizeTag(rows[0]);
 }
 
 export async function assignTag(
@@ -94,7 +111,7 @@ export async function getTagsForRequest(
           JOIN lab.request_tags t ON a.tag_id = t.id
          WHERE a.request_id = ${requestId}
     `;
-    return rows;
+    return rows.map(normalizeTag);
 }
 
 export async function getAllPrintRequests(
@@ -106,7 +123,7 @@ export async function getAllPrintRequests(
           FROM lab.print_requests
          WHERE lab_id = ${labId}
     `;
-    return rows;
+    return rows.map(normalizeRequest);
 }
 
 export async function listTags(
@@ -118,7 +135,7 @@ export async function listTags(
           FROM lab.request_tags
          WHERE lab_id = ${labId}
     `;
-    return rows;
+    return rows.map(normalizeTag);
 }
 
 export async function getPrintRequestById(
@@ -130,7 +147,7 @@ export async function getPrintRequestById(
           FROM lab.print_requests
          WHERE id = ${requestId}
     `;
-    return rows[0] ?? null;
+    return rows[0] ? normalizeRequest(rows[0]) : null;
 }
 
 export async function setRequestClosed(
@@ -144,5 +161,5 @@ export async function setRequestClosed(
          WHERE id = ${requestId}
         RETURNING id, lab_id, user_id, file_path, metadata, description, is_closed, created_at
     `;
-    return rows[0];
+    return normalizeRequest(rows[0]);
 }

--- a/slice-guard/backend/src/http/lab/index.ts
+++ b/slice-guard/backend/src/http/lab/index.ts
@@ -1,0 +1,3 @@
+export * from './lab';
+export * from './roles';
+export * from './members';

--- a/slice-guard/backend/src/http/lab/lab.ts
+++ b/slice-guard/backend/src/http/lab/lab.ts
@@ -8,6 +8,7 @@ import {
     getMemberRolePermissions,
 } from "../../db/lab";
 import { LabPermission } from "@shared/db/lab";
+import { hasLabPermission } from "../../utils/permissions";
 import type { LabCreatePayload, LabUpdatePayload } from "@shared/payloads";
 
 /**
@@ -53,7 +54,7 @@ export const update = withAuth(async (req, userId, state, params) => {
     const { name, description, imageUrl } =
         (await req.json()) as LabUpdatePayload;
     const perms = await getMemberRolePermissions(state.db, id, userId);
-    if (perms === null || !(perms & LabPermission.EDIT_LAB))
+    if (!hasLabPermission(perms, LabPermission.EDIT_LAB))
         return new Response("Unauthorized", { status: 403 });
     const lab = await updateLab(
         state.db,
@@ -73,7 +74,7 @@ export const del = withAuth(async (req, userId, state, params) => {
     const id = Number(params.id);
     const perms = await getMemberRolePermissions(state.db, id, userId);
 
-    if (perms === null || !(perms & LabPermission.DELETE_LAB))
+    if (!hasLabPermission(perms, LabPermission.DELETE_LAB))
         return new Response("Unauthorized", { status: 403 });
     await deleteLab(state.db, id);
 

--- a/slice-guard/backend/src/http/lab/lab.ts
+++ b/slice-guard/backend/src/http/lab/lab.ts
@@ -1,0 +1,81 @@
+import { withAuth } from "../middleware";
+import {
+    createLab,
+    updateLab,
+    deleteLab,
+    getLab,
+    listLabsForUser,
+    getMemberRolePermissions,
+} from "../../db/lab";
+import { LabPermission } from "@shared/db/lab";
+import type { LabCreatePayload, LabUpdatePayload } from "@shared/payloads";
+
+/**
+ * POST /api/labs
+ */
+export const create = withAuth(async (req, userId, state) => {
+    const { name, description, imageUrl } =
+        (await req.json()) as LabCreatePayload;
+    const lab = await createLab(
+        state.db,
+        userId,
+        name,
+        description ?? null,
+        imageUrl ?? null
+    );
+
+    return Response.json(lab);
+});
+
+/**
+ * GET /api/labs/:id
+ */
+export const get = withAuth(async (_req, _userId, state, params) => {
+    const lab = await getLab(state.db, Number(params.id));
+    if (!lab) return new Response("Not found", { status: 404 });
+
+    return Response.json(lab);
+});
+
+/**
+ * GET /api/labs
+ */
+export const list = withAuth(async (_req, userId, state) => {
+    const labs = await listLabsForUser(state.db, userId);
+    return Response.json(labs);
+});
+
+/**
+ * PATCH /api/labs/:id
+ */
+export const update = withAuth(async (req, userId, state, params) => {
+    const id = Number(params.id);
+    const { name, description, imageUrl } =
+        (await req.json()) as LabUpdatePayload;
+    const perms = await getMemberRolePermissions(state.db, id, userId);
+    if (perms === null || !(perms & LabPermission.EDIT_LAB))
+        return new Response("Unauthorized", { status: 403 });
+    const lab = await updateLab(
+        state.db,
+        id,
+        name,
+        description ?? null,
+        imageUrl ?? null
+    );
+
+    return Response.json(lab);
+});
+
+/**
+ * DELETE /api/labs/:id
+ */
+export const del = withAuth(async (req, userId, state, params) => {
+    const id = Number(params.id);
+    const perms = await getMemberRolePermissions(state.db, id, userId);
+
+    if (perms === null || !(perms & LabPermission.DELETE_LAB))
+        return new Response("Unauthorized", { status: 403 });
+    await deleteLab(state.db, id);
+
+    return new Response(null, { status: 204 });
+});

--- a/slice-guard/backend/src/http/lab/members.ts
+++ b/slice-guard/backend/src/http/lab/members.ts
@@ -1,111 +1,15 @@
-import { withAuth } from "./middleware";
+import { withAuth } from "../middleware";
 import {
-    createLab,
-    updateLab,
-    deleteLab,
-    createRole,
     addMember,
     removeMember,
     getMember,
     listMembers,
     getMemberRoles,
     getMemberRolePermissions,
-    getLab,
-    listLabsForUser,
-} from "../db/lab";
-import { findPublicUserById } from "../db/user";
+} from "../../db/lab";
+import { findPublicUserById } from "../../db/user";
 import { LabPermission, type LabMember } from "@shared/db/lab";
-import type {
-    LabCreatePayload,
-    LabUpdatePayload,
-    RoleCreatePayload,
-    MemberAddPayload,
-} from "@shared/payloads";
-
-/**
- * POST /api/labs
- */
-export const create = withAuth(async (req, userId, state) => {
-    const { name, description, imageUrl } =
-        (await req.json()) as LabCreatePayload;
-    const lab = await createLab(
-        state.db,
-        userId,
-        name,
-        description ?? null,
-        imageUrl ?? null
-    );
-
-    return Response.json(lab);
-});
-
-/**
- * GET /api/labs/:id
- */
-export const get = withAuth(async (_req, _userId, state, params) => {
-    const lab = await getLab(state.db, Number(params.id));
-    if (!lab) return new Response("Not found", { status: 404 });
-
-    return Response.json(lab);
-});
-
-/**
- * GET /api/labs
- */
-export const list = withAuth(async (_req, userId, state) => {
-    const labs = await listLabsForUser(state.db, userId);
-    return Response.json(labs);
-});
-
-/**
- * PATCH /api/labs/:id
- */
-export const update = withAuth(async (req, userId, state, params) => {
-    const id = Number(params.id);
-    const { name, description, imageUrl } =
-        (await req.json()) as LabUpdatePayload;
-    const perms = await getMemberRolePermissions(state.db, id, userId);
-    if (perms === null || !(perms & LabPermission.EDIT_LAB))
-        return new Response("Unauthorized", { status: 403 });
-    const lab = await updateLab(
-        state.db,
-        id,
-        name,
-        description ?? null,
-        imageUrl ?? null
-    );
-
-    return Response.json(lab);
-});
-
-/**
- * DELETE /api/labs/:id
- */
-export const del = withAuth(async (req, userId, state, params) => {
-    const id = Number(params.id);
-    const perms = await getMemberRolePermissions(state.db, id, userId);
-
-    if (perms === null || !(perms & LabPermission.DELETE_LAB))
-        return new Response("Unauthorized", { status: 403 });
-    await deleteLab(state.db, id);
-
-    return new Response(null, { status: 204 });
-});
-
-/**
- * POST /api/labs/:labId/roles
- */
-export const createRoleRoute = withAuth(async (req, userId, state, params) => {
-    const labId = Number(params.labId);
-    const { name, permissions } = (await req.json()) as RoleCreatePayload;
-
-    const perms = await getMemberRolePermissions(state.db, labId, userId);
-    if (perms === null || !(perms & LabPermission.MANAGE_ROLES))
-        return new Response("Unauthorized", { status: 403 });
-    const role = await createRole(state.db, labId, name, permissions);
-
-    return Response.json(role);
-});
+import type { MemberAddPayload } from "@shared/payloads";
 
 /**
  * POST /api/labs/:labId/members
@@ -135,8 +39,7 @@ export const removeMemberRoute = withAuth(async (req, userId, state, params) => 
 
     await removeMember(state.db, labId, removeId);
     return new Response(null, { status: 204 });
-}
-);
+});
 
 /**
  * GET /api/labs/:labId/members/:userId

--- a/slice-guard/backend/src/http/lab/members.ts
+++ b/slice-guard/backend/src/http/lab/members.ts
@@ -9,6 +9,7 @@ import {
 } from "../../db/lab";
 import { findPublicUserById } from "../../db/user";
 import { LabPermission, type LabMember } from "@shared/db/lab";
+import { hasLabPermission } from "../../utils/permissions";
 import type { MemberAddPayload } from "@shared/payloads";
 
 /**
@@ -19,7 +20,7 @@ export const addMemberRoute = withAuth(async (req, userId, state, params) => {
     const { userId: addId, roleId } = (await req.json()) as MemberAddPayload;
 
     const perms = await getMemberRolePermissions(state.db, labId, userId);
-    if (perms === null || !(perms & LabPermission.MANAGE_ROLES))
+    if (!hasLabPermission(perms, LabPermission.MANAGE_ROLES))
         return new Response("Unauthorized", { status: 403 });
 
     const member = await addMember(state.db, labId, addId, roleId ?? null);
@@ -34,7 +35,7 @@ export const removeMemberRoute = withAuth(async (req, userId, state, params) => 
     const removeId = Number(params.userId);
 
     const perms = await getMemberRolePermissions(state.db, labId, userId);
-    if (perms === null || !(perms & LabPermission.REMOVE_USER))
+    if (!hasLabPermission(perms, LabPermission.REMOVE_USER))
         return new Response("Unauthorized", { status: 403 });
 
     await removeMember(state.db, labId, removeId);

--- a/slice-guard/backend/src/http/lab/roles.ts
+++ b/slice-guard/backend/src/http/lab/roles.ts
@@ -1,6 +1,7 @@
 import { withAuth } from "../middleware";
 import { createRole, getMemberRolePermissions } from "../../db/lab";
 import { LabPermission } from "@shared/db/lab";
+import { hasLabPermission } from "../../utils/permissions";
 import type { RoleCreatePayload } from "@shared/payloads";
 
 /**
@@ -11,7 +12,7 @@ export const createRoleRoute = withAuth(async (req, userId, state, params) => {
     const { name, permissions } = (await req.json()) as RoleCreatePayload;
 
     const perms = await getMemberRolePermissions(state.db, labId, userId);
-    if (perms === null || !(perms & LabPermission.MANAGE_ROLES))
+    if (!hasLabPermission(perms, LabPermission.MANAGE_ROLES))
         return new Response("Unauthorized", { status: 403 });
     const role = await createRole(state.db, labId, name, permissions);
 

--- a/slice-guard/backend/src/http/lab/roles.ts
+++ b/slice-guard/backend/src/http/lab/roles.ts
@@ -1,0 +1,19 @@
+import { withAuth } from "../middleware";
+import { createRole, getMemberRolePermissions } from "../../db/lab";
+import { LabPermission } from "@shared/db/lab";
+import type { RoleCreatePayload } from "@shared/payloads";
+
+/**
+ * POST /api/labs/:labId/roles
+ */
+export const createRoleRoute = withAuth(async (req, userId, state, params) => {
+    const labId = Number(params.labId);
+    const { name, permissions } = (await req.json()) as RoleCreatePayload;
+
+    const perms = await getMemberRolePermissions(state.db, labId, userId);
+    if (perms === null || !(perms & LabPermission.MANAGE_ROLES))
+        return new Response("Unauthorized", { status: 403 });
+    const role = await createRole(state.db, labId, name, permissions);
+
+    return Response.json(role);
+});

--- a/slice-guard/backend/src/http/request.ts
+++ b/slice-guard/backend/src/http/request.ts
@@ -76,6 +76,23 @@ export const list = withAuth(async (req, userId, state, params) => {
 });
 
 /**
+ * GET /api/labs/:labId/requests/:requestId
+ */
+export const getRoute = withAuth(async (_req, userId, state, params) => {
+    const labId = Number(params.labId);
+    const requestId = Number(params.requestId);
+    const row = await getPrintRequestById(state.db, requestId);
+    if (!row || row.lab_id !== labId) return new Response('Not found', { status: 404 });
+    const perms = await getMemberRolePermissions(state.db, labId, userId);
+    if (row.user_id !== userId && (perms === null || !(perms & LabPermission.MANAGE_REQUESTS))) {
+        return new Response('Unauthorized', { status: 403 });
+    }
+    const user = await findPublicUserById(state.db, row.user_id);
+    const tags = await getTagsForRequest(state.db, requestId);
+    return Response.json({ request: row, user, tags });
+});
+
+/**
  * POST /api/labs/:labId/tags
  */
 export const createTagRoute = withAuth(async (req, userId, state, params) => {
@@ -92,11 +109,16 @@ export const createTagRoute = withAuth(async (req, userId, state, params) => {
 });
 
 /**
- * PATCH /api/tags/:tagId
+ * PATCH /api/labs/:labId/tags/:tagId
  */
-export const setTagDefaultRoute = withAuth(async (req, _userId, state, params) => {
+export const setTagDefaultRoute = withAuth(async (req, userId, state, params) => {
+    const labId = Number(params.labId);
     const tagId = Number(params.tagId);
     const { isDefault } = await req.json() as TagSetDefaultPayload;
+
+    const perms = await getMemberRolePermissions(state.db, labId, userId);
+    if (perms === null || !(perms & LabPermission.MANAGE_ROLES))
+        return new Response('Unauthorized', { status: 403 });
 
     state.logger.debug({ tagId, isDefault }, 'Setting tag default');
     const tag = await setTagDefault(state.db, tagId, isDefault);
@@ -116,14 +138,23 @@ export const listTagsRoute = withAuth(async (_req, userId, state, params) => {
 });
 
 /**
- * POST /api/requests/:requestId/tags/:tagId
+ * POST /api/labs/:labId/requests/:requestId/tags/:tagId
  */
-export const assignTagRoute = withAuth(async (req, _userId, state, params) => {
+export const assignTagRoute = withAuth(async (req, userId, state, params) => {
+    const labId = Number(params.labId);
     const requestId = Number(params.requestId);
     const tagId = Number(params.tagId);
 
     const { assign } = await req.json() as RequestAssignTagPayload;
     state.logger.debug({ requestId, tagId, assign }, 'Updating tag assignment');
+
+    const row = await getPrintRequestById(state.db, requestId);
+    if (!row || row.lab_id !== labId) return new Response('Not found', { status: 404 });
+    const perms = await getMemberRolePermissions(state.db, labId, userId);
+    if (row.user_id !== userId && (perms === null || !(perms & LabPermission.MANAGE_REQUESTS))) {
+        return new Response('Unauthorized', { status: 403 });
+    }
+
     if (assign) {
         await assignTag(state.db, requestId, tagId);
     } else {
@@ -133,14 +164,15 @@ export const assignTagRoute = withAuth(async (req, _userId, state, params) => {
 });
 
 /**
- * PATCH /api/requests/:requestId/state
+ * PATCH /api/labs/:labId/requests/:requestId
  */
 export const setRequestStateRoute = withAuth(async (req, userId, state, params) => {
+    const labId = Number(params.labId);
     const requestId = Number(params.requestId);
     const { isClosed } = await req.json() as RequestStateUpdatePayload;
     const row = await getPrintRequestById(state.db, requestId);
-    if (!row) return new Response('Not found', { status: 404 });
-    const perms = await getMemberRolePermissions(state.db, row.lab_id, userId);
+    if (!row || row.lab_id !== labId) return new Response('Not found', { status: 404 });
+    const perms = await getMemberRolePermissions(state.db, labId, userId);
     if (row.user_id !== userId && (perms === null || !(perms & LabPermission.MANAGE_REQUESTS))) {
         return new Response('Unauthorized', { status: 403 });
     }

--- a/slice-guard/backend/src/http/request.ts
+++ b/slice-guard/backend/src/http/request.ts
@@ -3,6 +3,8 @@ import {
     createPrintRequest,
     getUserPrintRequests,
     getAllPrintRequests,
+    getPrintRequestById,
+    setRequestClosed,
     createTag,
     setTagDefault,
     assignTag,
@@ -20,6 +22,7 @@ import type {
     TagCreatePayload,
     TagSetDefaultPayload,
     RequestAssignTagPayload,
+    RequestStateUpdatePayload,
 } from '@shared/payloads';
 
 /**
@@ -45,20 +48,30 @@ export const create = withAuth(async (req, userId, state, params) => {
 /**
  * GET /api/labs/:labId/requests
  */
-export const list = withAuth(async (_req, userId, state, params) => {
+export const list = withAuth(async (req, userId, state, params) => {
     const labId = Number(params.labId);
+    const url = new URL(req.url);
+    const stateFilter = url.searchParams.get('state');
     state.logger.debug({ labId, userId }, 'Listing requests');
     const perms = await getMemberRolePermissions(state.db, labId, userId);
     let rows = await getUserPrintRequests(state.db, labId, userId);
     if (perms !== null && (perms & LabPermission.MANAGE_REQUESTS)) {
         rows = await getAllPrintRequests(state.db, labId);
     }
+    if (stateFilter === 'open') rows = rows.filter(r => !r.is_closed);
+    else if (stateFilter === 'closed') rows = rows.filter(r => r.is_closed);
     const results = [] as any[];
     for (const r of rows) {
         const user = await findPublicUserById(state.db, r.user_id);
         const tags = await getTagsForRequest(state.db, r.id);
         results.push({ request: r, user, tags });
     }
+    results.sort((a, b) => {
+        if (a.request.is_closed !== b.request.is_closed) {
+            return a.request.is_closed ? 1 : -1;
+        }
+        return new Date(b.request.created_at).getTime() - new Date(a.request.created_at).getTime();
+    });
     return Response.json(results);
 });
 
@@ -117,4 +130,20 @@ export const assignTagRoute = withAuth(async (req, _userId, state, params) => {
         await unassignTag(state.db, requestId, tagId);
     }
     return new Response(null, { status: 204 });
+});
+
+/**
+ * PATCH /api/requests/:requestId/state
+ */
+export const setRequestStateRoute = withAuth(async (req, userId, state, params) => {
+    const requestId = Number(params.requestId);
+    const { isClosed } = await req.json() as RequestStateUpdatePayload;
+    const row = await getPrintRequestById(state.db, requestId);
+    if (!row) return new Response('Not found', { status: 404 });
+    const perms = await getMemberRolePermissions(state.db, row.lab_id, userId);
+    if (row.user_id !== userId && (perms === null || !(perms & LabPermission.MANAGE_REQUESTS))) {
+        return new Response('Unauthorized', { status: 403 });
+    }
+    const updated = await setRequestClosed(state.db, requestId, isClosed);
+    return Response.json(updated);
 });

--- a/slice-guard/backend/src/http/request.ts
+++ b/slice-guard/backend/src/http/request.ts
@@ -12,7 +12,7 @@ import {
     listTags,
     getTagsForRequest,
 } from '../db/request';
-import { saveRequestFile } from '../utils/storage';
+import { compressRequestFile } from '../utils/storage';
 import { getMemberRolePermissions } from '../db/lab';
 import { findPublicUserById } from '../db/user';
 import { LabPermission } from '@shared/db/lab';
@@ -40,8 +40,8 @@ export const create = withAuth(async (req, userId, state, params) => {
     }
 
     const buffer = Buffer.from(file, 'base64');
-    const path = await saveRequestFile(labId, buffer);
-    const result = await createPrintRequest(state.db, labId, userId, path, metadata, description ?? null);
+    const compressed = compressRequestFile(buffer);
+    const result = await createPrintRequest(state.db, labId, userId, compressed, metadata, description ?? null);
     state.logger.debug({ id: result.id }, 'Created print request');
     return Response.json(result);
 });

--- a/slice-guard/backend/src/http/request.ts
+++ b/slice-guard/backend/src/http/request.ts
@@ -16,6 +16,7 @@ import { saveRequestFile } from '../utils/storage';
 import { getMemberRolePermissions } from '../db/lab';
 import { findPublicUserById } from '../db/user';
 import { LabPermission } from '@shared/db/lab';
+import { hasLabPermission } from '../utils/permissions';
 import type {
     RequestCreatePayload,
     RequestListPayload,
@@ -34,7 +35,7 @@ export const create = withAuth(async (req, userId, state, params) => {
 
     state.logger.debug({ labId, userId }, 'Creating print request');
     const perms = await getMemberRolePermissions(state.db, labId, userId);
-    if (perms !== null && !(perms & LabPermission.CREATE_REQUEST)) {
+    if (perms !== null && !hasLabPermission(perms, LabPermission.CREATE_REQUEST)) {
         return new Response('Unauthorized', { status: 403 });
     }
 
@@ -84,7 +85,7 @@ export const getRoute = withAuth(async (_req, userId, state, params) => {
     const row = await getPrintRequestById(state.db, requestId);
     if (!row || row.lab_id !== labId) return new Response('Not found', { status: 404 });
     const perms = await getMemberRolePermissions(state.db, labId, userId);
-    if (row.user_id !== userId && (perms === null || !(perms & LabPermission.MANAGE_REQUESTS))) {
+    if (row.user_id !== userId && !hasLabPermission(perms, LabPermission.MANAGE_REQUESTS)) {
         return new Response('Unauthorized', { status: 403 });
     }
     const user = await findPublicUserById(state.db, row.user_id);
@@ -100,7 +101,7 @@ export const createTagRoute = withAuth(async (req, userId, state, params) => {
     const { name, isDefault } = await req.json() as TagCreatePayload;
 
     const perms = await getMemberRolePermissions(state.db, labId, userId);
-    if (perms === null || !(perms & LabPermission.MANAGE_ROLES))
+    if (!hasLabPermission(perms, LabPermission.MANAGE_ROLES))
         return new Response('Unauthorized', { status: 403 });
     state.logger.debug({ labId, name }, 'Creating tag');
     const tag = await createTag(state.db, labId, name, isDefault ?? false);
@@ -117,7 +118,7 @@ export const setTagDefaultRoute = withAuth(async (req, userId, state, params) =>
     const { isDefault } = await req.json() as TagSetDefaultPayload;
 
     const perms = await getMemberRolePermissions(state.db, labId, userId);
-    if (perms === null || !(perms & LabPermission.MANAGE_ROLES))
+    if (!hasLabPermission(perms, LabPermission.MANAGE_ROLES))
         return new Response('Unauthorized', { status: 403 });
 
     state.logger.debug({ tagId, isDefault }, 'Setting tag default');
@@ -151,7 +152,7 @@ export const assignTagRoute = withAuth(async (req, userId, state, params) => {
     const row = await getPrintRequestById(state.db, requestId);
     if (!row || row.lab_id !== labId) return new Response('Not found', { status: 404 });
     const perms = await getMemberRolePermissions(state.db, labId, userId);
-    if (row.user_id !== userId && (perms === null || !(perms & LabPermission.MANAGE_REQUESTS))) {
+    if (row.user_id !== userId && !hasLabPermission(perms, LabPermission.MANAGE_REQUESTS)) {
         return new Response('Unauthorized', { status: 403 });
     }
 
@@ -173,7 +174,7 @@ export const setRequestStateRoute = withAuth(async (req, userId, state, params) 
     const row = await getPrintRequestById(state.db, requestId);
     if (!row || row.lab_id !== labId) return new Response('Not found', { status: 404 });
     const perms = await getMemberRolePermissions(state.db, labId, userId);
-    if (row.user_id !== userId && (perms === null || !(perms & LabPermission.MANAGE_REQUESTS))) {
+    if (row.user_id !== userId && !hasLabPermission(perms, LabPermission.MANAGE_REQUESTS)) {
         return new Response('Unauthorized', { status: 403 });
     }
     const updated = await setRequestClosed(state.db, requestId, isClosed);

--- a/slice-guard/backend/src/http/request.ts
+++ b/slice-guard/backend/src/http/request.ts
@@ -1,7 +1,18 @@
 import { withAuth } from './middleware';
-import { createPrintRequest, getUserPrintRequests, createTag, setTagDefault, assignTag, unassignTag } from '../db/request';
+import {
+    createPrintRequest,
+    getUserPrintRequests,
+    getAllPrintRequests,
+    createTag,
+    setTagDefault,
+    assignTag,
+    unassignTag,
+    listTags,
+    getTagsForRequest,
+} from '../db/request';
 import { saveRequestFile } from '../utils/storage';
 import { getMemberRolePermissions } from '../db/lab';
+import { findPublicUserById } from '../db/user';
 import { LabPermission } from '@shared/db/lab';
 import type {
     RequestCreatePayload,
@@ -37,8 +48,18 @@ export const create = withAuth(async (req, userId, state, params) => {
 export const list = withAuth(async (_req, userId, state, params) => {
     const labId = Number(params.labId);
     state.logger.debug({ labId, userId }, 'Listing requests');
-    const reqs = await getUserPrintRequests(state.db, labId, userId);
-    return Response.json(reqs);
+    const perms = await getMemberRolePermissions(state.db, labId, userId);
+    let rows = await getUserPrintRequests(state.db, labId, userId);
+    if (perms !== null && (perms & LabPermission.MANAGE_REQUESTS)) {
+        rows = await getAllPrintRequests(state.db, labId);
+    }
+    const results = [] as any[];
+    for (const r of rows) {
+        const user = await findPublicUserById(state.db, r.user_id);
+        const tags = await getTagsForRequest(state.db, r.id);
+        results.push({ request: r, user, tags });
+    }
+    return Response.json(results);
 });
 
 /**
@@ -68,6 +89,17 @@ export const setTagDefaultRoute = withAuth(async (req, _userId, state, params) =
     const tag = await setTagDefault(state.db, tagId, isDefault);
     state.logger.debug({ tagId }, 'Updated tag');
     return Response.json(tag);
+});
+
+/**
+ * GET /api/labs/:labId/tags
+ */
+export const listTagsRoute = withAuth(async (_req, userId, state, params) => {
+    const labId = Number(params.labId);
+    const perms = await getMemberRolePermissions(state.db, labId, userId);
+    if (perms === null) return new Response('Unauthorized', { status: 403 });
+    const tags = await listTags(state.db, labId);
+    return Response.json(tags);
 });
 
 /**

--- a/slice-guard/backend/src/server.ts
+++ b/slice-guard/backend/src/server.ts
@@ -68,6 +68,9 @@ export class Server {
                 '/api/requests/:requestId/tags/:tagId': {
                     POST: req => withLogging(requestHandlers.assignTagRoute)(req, this.state, req.params),
                 },
+                '/api/requests/:requestId/state': {
+                    PATCH: req => withLogging(requestHandlers.setRequestStateRoute)(req, this.state, req.params),
+                },
                 '/api/*': {
                     OPTIONS: _req => {
                         // Handle CORS preflight (in the future)

--- a/slice-guard/backend/src/server.ts
+++ b/slice-guard/backend/src/server.ts
@@ -60,6 +60,7 @@ export class Server {
                 },
                 '/api/labs/:labId/tags': {
                     POST: req => withLogging(requestHandlers.createTagRoute)(req, this.state, req.params),
+                    GET: req => withLogging(requestHandlers.listTagsRoute)(req, this.state, req.params),
                 },
                 '/api/tags/:tagId': {
                     PATCH: req => withLogging(requestHandlers.setTagDefaultRoute)(req, this.state, req.params),

--- a/slice-guard/backend/src/server.ts
+++ b/slice-guard/backend/src/server.ts
@@ -58,18 +58,19 @@ export class Server {
                     POST: req => withLogging(requestHandlers.create)(req, this.state, req.params),
                     GET: req => withLogging(requestHandlers.list)(req, this.state, req.params),
                 },
+                '/api/labs/:labId/requests/:requestId': {
+                    GET: req => withLogging(requestHandlers.getRoute)(req, this.state, req.params),
+                    PATCH: req => withLogging(requestHandlers.setRequestStateRoute)(req, this.state, req.params),
+                },
+                '/api/labs/:labId/requests/:requestId/tags/:tagId': {
+                    POST: req => withLogging(requestHandlers.assignTagRoute)(req, this.state, req.params),
+                },
                 '/api/labs/:labId/tags': {
                     POST: req => withLogging(requestHandlers.createTagRoute)(req, this.state, req.params),
                     GET: req => withLogging(requestHandlers.listTagsRoute)(req, this.state, req.params),
                 },
-                '/api/tags/:tagId': {
+                '/api/labs/:labId/tags/:tagId': {
                     PATCH: req => withLogging(requestHandlers.setTagDefaultRoute)(req, this.state, req.params),
-                },
-                '/api/requests/:requestId/tags/:tagId': {
-                    POST: req => withLogging(requestHandlers.assignTagRoute)(req, this.state, req.params),
-                },
-                '/api/requests/:requestId/state': {
-                    PATCH: req => withLogging(requestHandlers.setRequestStateRoute)(req, this.state, req.params),
                 },
                 '/api/*': {
                     OPTIONS: _req => {

--- a/slice-guard/backend/src/utils/permissions.ts
+++ b/slice-guard/backend/src/utils/permissions.ts
@@ -1,0 +1,7 @@
+import { LabPermission } from "@shared/db/lab";
+
+export function hasLabPermission(perms: number | null, perm: LabPermission): boolean {
+    if (perms === null) return false;
+    return (perms & LabPermission.ALL) !== 0 || (perms & perm) !== 0;
+}
+

--- a/slice-guard/backend/src/utils/storage.ts
+++ b/slice-guard/backend/src/utils/storage.ts
@@ -1,22 +1,15 @@
-import { promises as fs } from "fs";
 import { gzipSync } from "zlib";
 
 export const MAX_UPLOAD_SIZE = 30 * 1024 * 1024; // 30MB
 
 /**
- * Saves a print request file to the uploads directory. The file is gzipped to
- * reduce disk usage. Returns the path to the stored file.
+ * Gzips a print request file after validating its size. The compressed data can
+ * then be stored directly in the database.
  */
-export async function saveRequestFile(labId: number, data: ArrayBuffer | Uint8Array): Promise<string> {
+export function compressRequestFile(data: ArrayBuffer | Uint8Array): Buffer {
     if (data.byteLength > MAX_UPLOAD_SIZE) {
         throw new Error('File exceeds maximum allowed size');
     }
-    const dir = `./uploads/${labId}`;
-    await fs.mkdir(dir, { recursive: true });
-    const name = `${crypto.randomUUID()}.3mf.gz`;
-    const path = `${dir}/${name}`;
     const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
-    const compressed = gzipSync(bytes);
-    await fs.writeFile(path, compressed);
-    return path;
+    return gzipSync(bytes);
 }

--- a/slice-guard/backend/tests/lab.test.ts
+++ b/slice-guard/backend/tests/lab.test.ts
@@ -131,12 +131,16 @@ test("removeMember deletes by composite id", async () => {
 });
 
 test("getMemberRolePermissions selects join", async () => {
-  const db = createMockSQL([[{ permissions: 8 }]]);
+  const db = createMockSQL([[{ owner_id: 3 }], [{ permissions: 8 }]]);
   const result = await getMemberRolePermissions(db as any, 1, 2);
-  expect(normalize(db.queries.at(-1))).toBe(
+  expect(normalize(db.queries[0])).toBe(
+    "SELECT owner_id FROM lab.labs WHERE id = $1"
+  );
+  expect(db.params[0]).toEqual([1]);
+  expect(normalize(db.queries[1])).toBe(
     "SELECT r.permissions FROM lab.member_roles mr JOIN lab.roles r ON mr.role_id = r.id WHERE mr.lab_id = $1 AND mr.user_id = $2"
   );
-  expect(db.params.at(-1)).toEqual([1, 2]);
+  expect(db.params[1]).toEqual([1, 2]);
   expect(result).toEqual(8);
 });
 

--- a/slice-guard/backend/tests/request.test.ts
+++ b/slice-guard/backend/tests/request.test.ts
@@ -35,6 +35,7 @@ function sampleRequest(): PrintRequestRow {
     file_data: new Uint8Array([1, 2, 3]),
     metadata: { a: 1 },
     description: "desc",
+    is_closed: false,
     created_at: new Date(),
   };
 }
@@ -54,7 +55,7 @@ test("createPrintRequest inserts expected values", async () => {
   const db = createMockSQL([req]);
   const result = await createPrintRequest(db as any, req.lab_id, req.user_id, req.file_data as any, req.metadata, req.description!);
   expect(normalize(db.lastQuery)).toBe(
-    "INSERT INTO lab.print_requests (lab_id, user_id, file_data, metadata, description) VALUES ($1, $2, $3, $4, $5) RETURNING id, lab_id, user_id, file_data, metadata, description, created_at"
+    "INSERT INTO lab.print_requests (lab_id, user_id, file_data, metadata, description) VALUES ($1, $2, $3, $4, $5) RETURNING id, lab_id, user_id, file_data, metadata, description, is_closed, created_at"
   );
   expect(db.lastParams).toEqual([req.lab_id, req.user_id, req.file_data, JSON.stringify(req.metadata), req.description]);
   expect(result).toEqual(req);
@@ -65,7 +66,7 @@ test("getUserPrintRequests selects expected", async () => {
   const db = createMockSQL([req]);
   const result = await getUserPrintRequests(db as any, req.lab_id, req.user_id);
   expect(normalize(db.lastQuery)).toBe(
-    "SELECT id, lab_id, user_id, file_data, metadata, description, created_at FROM lab.print_requests WHERE lab_id = $1 AND user_id = $2"
+    "SELECT id, lab_id, user_id, file_data, metadata, description, is_closed, created_at FROM lab.print_requests WHERE lab_id = $1 AND user_id = $2"
   );
   expect(db.lastParams).toEqual([req.lab_id, req.user_id]);
   expect(result).toEqual([req]);

--- a/slice-guard/backend/tests/request.test.ts
+++ b/slice-guard/backend/tests/request.test.ts
@@ -32,7 +32,7 @@ function sampleRequest(): PrintRequestRow {
     id: 1,
     lab_id: 1,
     user_id: 2,
-    file_path: "path",
+    file_data: new Uint8Array([1, 2, 3]),
     metadata: { a: 1 },
     description: "desc",
     created_at: new Date(),
@@ -52,11 +52,11 @@ function sampleTag(): RequestTagRow {
 test("createPrintRequest inserts expected values", async () => {
   const req = sampleRequest();
   const db = createMockSQL([req]);
-  const result = await createPrintRequest(db as any, req.lab_id, req.user_id, req.file_path, req.metadata, req.description!);
+  const result = await createPrintRequest(db as any, req.lab_id, req.user_id, req.file_data as any, req.metadata, req.description!);
   expect(normalize(db.lastQuery)).toBe(
-    "INSERT INTO lab.print_requests (lab_id, user_id, file_path, metadata, description) VALUES ($1, $2, $3, $4, $5) RETURNING id, lab_id, user_id, file_path, metadata, description, created_at"
+    "INSERT INTO lab.print_requests (lab_id, user_id, file_data, metadata, description) VALUES ($1, $2, $3, $4, $5) RETURNING id, lab_id, user_id, file_data, metadata, description, created_at"
   );
-  expect(db.lastParams).toEqual([req.lab_id, req.user_id, req.file_path, JSON.stringify(req.metadata), req.description]);
+  expect(db.lastParams).toEqual([req.lab_id, req.user_id, req.file_data, JSON.stringify(req.metadata), req.description]);
   expect(result).toEqual(req);
 });
 
@@ -65,7 +65,7 @@ test("getUserPrintRequests selects expected", async () => {
   const db = createMockSQL([req]);
   const result = await getUserPrintRequests(db as any, req.lab_id, req.user_id);
   expect(normalize(db.lastQuery)).toBe(
-    "SELECT id, lab_id, user_id, file_path, metadata, description, created_at FROM lab.print_requests WHERE lab_id = $1 AND user_id = $2"
+    "SELECT id, lab_id, user_id, file_data, metadata, description, created_at FROM lab.print_requests WHERE lab_id = $1 AND user_id = $2"
   );
   expect(db.lastParams).toEqual([req.lab_id, req.user_id]);
   expect(result).toEqual([req]);

--- a/slice-guard/backend/tests/storage.test.ts
+++ b/slice-guard/backend/tests/storage.test.ts
@@ -1,27 +1,16 @@
 import { expect, test } from "bun:test";
-import { saveRequestFile, MAX_UPLOAD_SIZE } from "../src/utils/storage";
-import { existsSync, rmSync, readFileSync } from "fs";
-
-const dir = "slice-guard/backend/uploads/1";
-
-function cleanup() {
-  if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
-}
-
-cleanup();
+import { compressRequestFile, MAX_UPLOAD_SIZE } from "../src/utils/storage";
+import { gzipSync } from "zlib";
 
 const sample = new TextEncoder().encode("hello world");
 
-test("saveRequestFile stores gzipped file", async () => {
-  const path = await saveRequestFile(1, sample);
-  expect(existsSync(path)).toBe(true);
-  const contents = readFileSync(path);
-  expect(contents.length).toBeGreaterThan(0);
+test("compressRequestFile gzips the data", () => {
+  const compressed = compressRequestFile(sample);
+  const expected = gzipSync(sample);
+  expect(compressed.equals(expected)).toBe(true);
 });
 
-test("saveRequestFile rejects large files", async () => {
+test("compressRequestFile rejects large files", () => {
   const big = new Uint8Array(MAX_UPLOAD_SIZE + 1);
-  await expect(saveRequestFile(1, big)).rejects.toThrow();
+  expect(() => compressRequestFile(big)).toThrow();
 });
-
-cleanup();

--- a/slice-guard/frontend/src/router/index.ts
+++ b/slice-guard/frontend/src/router/index.ts
@@ -58,7 +58,10 @@ const router = createRouter({
 
 router.beforeEach((to) => {
   const auth = useAuthStore()
-  if (to.name === 'Login' || to.name === 'Register') return true
+  if (to.name === 'Login' || to.name === 'Register') {
+    if (auth.apiKey) return { name: 'Root' }
+    return true
+  }
   if (!auth.apiKey) return { name: 'Login' }
   return true
 })

--- a/slice-guard/frontend/src/services/api.ts
+++ b/slice-guard/frontend/src/services/api.ts
@@ -1,0 +1,12 @@
+import { useAuthStore } from '../store/auth'
+
+const API_URL = (import.meta as any).env.VITE_API_URL ?? '/api'
+
+export function apiFetch(input: string, init: RequestInit = {}) {
+  const auth = useAuthStore()
+  const headers = new Headers(init.headers)
+  if (auth.apiKey) headers.set('Authorization', `ApiKey ${auth.apiKey}`)
+  return fetch(`${API_URL}${input}`, { ...init, headers })
+}
+
+export { API_URL }

--- a/slice-guard/frontend/src/services/auth.ts
+++ b/slice-guard/frontend/src/services/auth.ts
@@ -1,14 +1,13 @@
 import { ws } from "./ws";
 import { useAuthStore } from "../store/auth";
-
-const API_URL = (import.meta as any).env.VITE_API_URL ?? "/api";
+import { apiFetch } from "./api";
 
 const auth = useAuthStore();
 
 export async function login(email: string, password: string) {
-  const res = await fetch(`${API_URL}/login`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+  const res = await apiFetch('/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email, password }),
   });
 
@@ -22,9 +21,9 @@ export async function login(email: string, password: string) {
 }
 
 export async function register(email: string, password: string, name: string) {
-  const res = await fetch(`${API_URL}/register`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+  const res = await apiFetch('/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email, password, name }),
   });
 
@@ -39,12 +38,4 @@ export async function register(email: string, password: string, name: string) {
 
 export function logout() {
   auth.clearSession();
-}
-
-export async function authorizedFetch(input: string, init: RequestInit = {}) {
-  if (!auth.apiKey) throw new Error("Not authenticated");
-  const headers = new Headers(init.headers);
-
-  headers.set("Authorization", `ApiKey ${auth.apiKey}`);
-  return fetch(`${API_URL}${input}`, { ...init, headers });
 }

--- a/slice-guard/frontend/src/views/CreateLabView.vue
+++ b/slice-guard/frontend/src/views/CreateLabView.vue
@@ -2,7 +2,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import Button from '../components/Button.vue'
-import { authorizedFetch } from '../services/auth'
+import { apiFetch } from '../services/api'
 
 const name = ref('')
 const description = ref('')
@@ -13,7 +13,7 @@ const router = useRouter()
 async function submit() {
   error.value = ''
   try {
-    const res = await authorizedFetch('/labs', {
+    const res = await apiFetch('/labs', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: name.value, description: description.value || undefined, imageUrl: imageUrl.value || undefined }),

--- a/slice-guard/frontend/src/views/RootRedirect.vue
+++ b/slice-guard/frontend/src/views/RootRedirect.vue
@@ -2,7 +2,7 @@
 import { onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '../store/auth'
-import { authorizedFetch } from '../services/auth'
+import { apiFetch } from '../services/api'
 
 const router = useRouter()
 const auth = useAuthStore()
@@ -19,7 +19,7 @@ onMounted(async () => {
   }
 
   try {
-    const res = await authorizedFetch('/labs')
+    const res = await apiFetch('/labs')
 
     if (!res.ok) throw new Error()
     const labs = await res.json()

--- a/slice-guard/frontend/src/views/auth/LoginPage.vue
+++ b/slice-guard/frontend/src/views/auth/LoginPage.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import Button from '../../components/Button.vue';
 import { login } from '../../services/auth';
+import { useAuthStore } from '../../store/auth';
 
 const email = ref('');
 const password = ref('');
 const error = ref('');
 const router = useRouter();
+const auth = useAuthStore();
+
+onMounted(() => {
+  if (auth.apiKey) router.replace('/');
+});
 
 async function submit() {
   error.value = '';

--- a/slice-guard/frontend/src/views/auth/RegisterPage.vue
+++ b/slice-guard/frontend/src/views/auth/RegisterPage.vue
@@ -1,14 +1,23 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import Button from '../../components/Button.vue'
 import { register } from '../../services/auth'
+import { useAuthStore } from '../../store/auth'
 
 const name = ref('')
 const email = ref('')
 const password = ref('')
 const error = ref('')
 const router = useRouter()
+const auth = useAuthStore()
+
+onMounted(() => {
+  if (auth.apiKey) {
+    alert('Please logout before creating a new account.')
+    router.replace('/')
+  }
+})
 
 async function submit() {
   error.value = ''

--- a/slice-guard/frontend/src/views/lab/LabDashboard.vue
+++ b/slice-guard/frontend/src/views/lab/LabDashboard.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import ThemeToggle from '../../components/ThemeToggle.vue';
+import { ref } from 'vue'
+import { authorizedFetch } from '../../services/auth'
 
 interface Props {
     lab: any | null
@@ -8,6 +10,27 @@ interface Props {
 }
 
 defineProps<Props>()
+
+const tagName = ref('')
+
+async function createTag() {
+    if (!props.lab) return
+    await authorizedFetch(`/labs/${props.lab.id}/tags`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: tagName.value }),
+    })
+    tagName.value = ''
+}
+
+async function createMockRequest() {
+    if (!props.lab) return
+    await authorizedFetch(`/labs/${props.lab.id}/requests`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ file: btoa('mock'), metadata: {}, description: 'Mock request' }),
+    })
+}
 
 
 
@@ -25,5 +48,15 @@ defineProps<Props>()
 
     <!-- Theme Toggle Button -->
     <ThemeToggle class="mt-4" variant="secondary" />
+
+    <!-- Development helpers -->
+    <div class="mt-6 space-y-2">
+        <h2 class="text-fg-primary font-semibold">Dev Tools</h2>
+        <div class="flex gap-2 items-center">
+            <input v-model="tagName" placeholder="Tag name" class="bg-surface-low px-2 py-1 rounded-md" />
+            <button @click="createTag" class="bg-salem-800 text-white px-2 py-1 rounded-md">Create Tag</button>
+        </div>
+        <button @click="createMockRequest" class="bg-surface-low px-2 py-1 rounded-md">Create Mock Request</button>
+    </div>
 
 </template>

--- a/slice-guard/frontend/src/views/lab/LabDashboard.vue
+++ b/slice-guard/frontend/src/views/lab/LabDashboard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import ThemeToggle from '../../components/ThemeToggle.vue';
 import { ref } from 'vue'
-import { authorizedFetch } from '../../services/auth'
+import { apiFetch } from '../../services/api'
 
 interface Props {
     lab: any | null
@@ -15,7 +15,7 @@ const tagName = ref('')
 
 async function createTag() {
     if (!props.lab) return
-    await authorizedFetch(`/labs/${props.lab.id}/tags`, {
+    await apiFetch(`/labs/${props.lab.id}/tags`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: tagName.value }),
@@ -25,7 +25,7 @@ async function createTag() {
 
 async function createMockRequest() {
     if (!props.lab) return
-    await authorizedFetch(`/labs/${props.lab.id}/requests`, {
+    await apiFetch(`/labs/${props.lab.id}/requests`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ file: btoa('mock'), metadata: {}, description: 'Mock request' }),

--- a/slice-guard/frontend/src/views/lab/LabDashboard.vue
+++ b/slice-guard/frontend/src/views/lab/LabDashboard.vue
@@ -9,7 +9,7 @@ interface Props {
     loading: boolean
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
 
 const tagName = ref('')
 

--- a/slice-guard/frontend/src/views/lab/LabLayout.vue
+++ b/slice-guard/frontend/src/views/lab/LabLayout.vue
@@ -3,7 +3,7 @@ import { onMounted, watch, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import Sidebar from './Sidebar.vue'
 import LabUserList from './LabUserList.vue'
-import { authorizedFetch } from '../../services/auth'
+import { apiFetch } from '../../services/api'
 import { type Lab } from '@shared/db/lab';
 
 const route = useRoute()
@@ -17,7 +17,7 @@ async function fetchLab() {
   loading.value = true
   error.value = ''
   try {
-    const res = await authorizedFetch(`/labs/${labId}`)
+    const res = await apiFetch(`/labs/${labId}`)
     if (!res.ok) throw new Error()
     lab.value = await res.json()
   } catch {

--- a/slice-guard/frontend/src/views/lab/LabPrintRequests.vue
+++ b/slice-guard/frontend/src/views/lab/LabPrintRequests.vue
@@ -4,6 +4,7 @@ import { useRoute } from 'vue-router'
 import { authorizedFetch } from '../../services/auth'
 import type { PrintRequest, RequestTag } from '@shared/db/request'
 import type { User } from '@shared/db/user'
+import { useAuthStore } from '../../store/auth'
 
 interface RequestItem {
   request: PrintRequest
@@ -16,14 +17,17 @@ const labId = computed(() => Number(route.params.id))
 
 const requests = ref<RequestItem[]>([])
 const tags = ref<RequestTag[]>([])
+const auth = useAuthStore()
 
 const search = ref('')
 const tagFilter = ref<number | null>(null)
 const from = ref('')
 const to = ref('')
+const stateFilter = ref<'all' | 'open' | 'closed'>('all')
 
 async function fetchRequests() {
-  const res = await authorizedFetch(`/labs/${labId.value}/requests`)
+  const q = stateFilter.value === 'all' ? '' : `?state=${stateFilter.value}`
+  const res = await authorizedFetch(`/labs/${labId.value}/requests${q}`)
   if (res.ok) requests.value = await res.json()
 }
 
@@ -40,6 +44,7 @@ watch(labId, () => {
   fetchRequests()
   fetchTags()
 })
+watch(stateFilter, fetchRequests)
 
 const filtered = computed(() => {
   return requests.value
@@ -54,8 +59,27 @@ const filtered = computed(() => {
       if (to.value && new Date(r.request.created_at) > new Date(to.value)) return false
       return true
     })
-    .sort((a, b) => new Date(b.request.created_at).getTime() - new Date(a.request.created_at).getTime())
+    .filter(r => {
+      if (stateFilter.value === 'open') return !r.request.is_closed
+      if (stateFilter.value === 'closed') return r.request.is_closed
+      return true
+    })
+    .sort((a, b) => {
+      if (a.request.is_closed !== b.request.is_closed) return a.request.is_closed ? 1 : -1
+      return new Date(b.request.created_at).getTime() - new Date(a.request.created_at).getTime()
+    })
 })
+
+async function toggleState(item: RequestItem) {
+  const res = await authorizedFetch(`/requests/${item.request.id}/state`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ isClosed: !item.request.is_closed })
+  })
+  if (res.ok) {
+    item.request.is_closed = !item.request.is_closed
+  }
+}
 </script>
 
 <template>
@@ -68,6 +92,11 @@ const filtered = computed(() => {
       </select>
       <input type="date" v-model="from" class="bg-surface-low px-2 py-1 rounded-md" />
       <input type="date" v-model="to" class="bg-surface-low px-2 py-1 rounded-md" />
+      <select v-model="stateFilter" class="bg-surface-low px-2 py-1 rounded-md">
+        <option value="all">All</option>
+        <option value="open">Open</option>
+        <option value="closed">Closed</option>
+      </select>
     </div>
     <div class="space-y-2">
       <div
@@ -78,6 +107,13 @@ const filtered = computed(() => {
         <div class="text-sm font-medium text-fg-primary">{{ item.user?.name || item.user?.email }}</div>
         <div class="text-xs text-fg-secondary">{{ item.request.description }}</div>
         <div class="text-xs text-fg-tertiary">{{ new Date(item.request.created_at).toLocaleString() }}</div>
+        <button
+          v-if="auth.user?.id === item.request.user_id"
+          @click.stop="toggleState(item)"
+          class="text-xs text-salem-800 underline"
+        >
+          {{ item.request.is_closed ? 'Reopen' : 'Close' }}
+        </button>
       </div>
     </div>
   </div>

--- a/slice-guard/frontend/src/views/lab/LabPrintRequests.vue
+++ b/slice-guard/frontend/src/views/lab/LabPrintRequests.vue
@@ -1,8 +1,84 @@
 <script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { authorizedFetch } from '../../services/auth'
+import type { PrintRequest, RequestTag } from '@shared/db/request'
+import type { User } from '@shared/db/user'
+
+interface RequestItem {
+  request: PrintRequest
+  user: User | null
+  tags: RequestTag[]
+}
+
+const route = useRoute()
+const labId = computed(() => Number(route.params.id))
+
+const requests = ref<RequestItem[]>([])
+const tags = ref<RequestTag[]>([])
+
+const search = ref('')
+const tagFilter = ref<number | null>(null)
+const from = ref('')
+const to = ref('')
+
+async function fetchRequests() {
+  const res = await authorizedFetch(`/labs/${labId.value}/requests`)
+  if (res.ok) requests.value = await res.json()
+}
+
+async function fetchTags() {
+  const res = await authorizedFetch(`/labs/${labId.value}/tags`)
+  if (res.ok) tags.value = await res.json()
+}
+
+onMounted(() => {
+  fetchRequests()
+  fetchTags()
+})
+watch(labId, () => {
+  fetchRequests()
+  fetchTags()
+})
+
+const filtered = computed(() => {
+  return requests.value
+    .filter(r =>
+      !search.value ||
+      r.request.description?.toLowerCase().includes(search.value.toLowerCase()) ||
+      r.user?.name?.toLowerCase().includes(search.value.toLowerCase())
+    )
+    .filter(r => !tagFilter.value || r.tags.some(t => t.id === tagFilter.value))
+    .filter(r => {
+      if (from.value && new Date(r.request.created_at) < new Date(from.value)) return false
+      if (to.value && new Date(r.request.created_at) > new Date(to.value)) return false
+      return true
+    })
+    .sort((a, b) => new Date(b.request.created_at).getTime() - new Date(a.request.created_at).getTime())
+})
 </script>
 
 <template>
-    <div class="text-fg-primary">
-        I am the Lab Print Requests page.
+  <div class="space-y-4">
+    <div class="flex flex-wrap gap-2 items-center">
+      <input v-model="search" placeholder="Search" class="bg-surface-low px-2 py-1 rounded-md" />
+      <select v-model.number="tagFilter" class="bg-surface-low px-2 py-1 rounded-md">
+        <option :value="null">All Tags</option>
+        <option v-for="t in tags" :key="t.id" :value="t.id">{{ t.name }}</option>
+      </select>
+      <input type="date" v-model="from" class="bg-surface-low px-2 py-1 rounded-md" />
+      <input type="date" v-model="to" class="bg-surface-low px-2 py-1 rounded-md" />
     </div>
+    <div class="space-y-2">
+      <div
+        v-for="item in filtered"
+        :key="item.request.id"
+        class="bg-surface shadow px-4 py-2 rounded-lg cursor-pointer hover:shadow-md"
+      >
+        <div class="text-sm font-medium text-fg-primary">{{ item.user?.name || item.user?.email }}</div>
+        <div class="text-xs text-fg-secondary">{{ item.request.description }}</div>
+        <div class="text-xs text-fg-tertiary">{{ new Date(item.request.created_at).toLocaleString() }}</div>
+      </div>
+    </div>
+  </div>
 </template>

--- a/slice-guard/frontend/src/views/lab/LabPrintRequests.vue
+++ b/slice-guard/frontend/src/views/lab/LabPrintRequests.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
-import { authorizedFetch } from '../../services/auth'
+import { apiFetch } from '../../services/api'
 import type { PrintRequest, RequestTag } from '@shared/db/request'
 import type { User } from '@shared/db/user'
 import { useAuthStore } from '../../store/auth'
@@ -27,12 +27,12 @@ const stateFilter = ref<'all' | 'open' | 'closed'>('all')
 
 async function fetchRequests() {
   const q = stateFilter.value === 'all' ? '' : `?state=${stateFilter.value}`
-  const res = await authorizedFetch(`/labs/${labId.value}/requests${q}`)
+  const res = await apiFetch(`/labs/${labId.value}/requests${q}`)
   if (res.ok) requests.value = await res.json()
 }
 
 async function fetchTags() {
-  const res = await authorizedFetch(`/labs/${labId.value}/tags`)
+  const res = await apiFetch(`/labs/${labId.value}/tags`)
   if (res.ok) tags.value = await res.json()
 }
 
@@ -71,7 +71,7 @@ const filtered = computed(() => {
 })
 
 async function toggleState(item: RequestItem) {
-  const res = await authorizedFetch(`/requests/${item.request.id}/state`, {
+  const res = await apiFetch(`/labs/${labId.value}/requests/${item.request.id}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ isClosed: !item.request.is_closed })

--- a/slice-guard/frontend/src/views/lab/LabUserList.vue
+++ b/slice-guard/frontend/src/views/lab/LabUserList.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted, watch } from 'vue'
 import type { Lab, LabMember } from '@shared/db/lab'
 import type { User } from '@shared/db/user'
-import { authorizedFetch } from '../../services/auth'
+import { apiFetch } from '../../services/api'
 
 const props = defineProps<{
     lab: Lab | null
@@ -17,7 +17,7 @@ const members = ref<Record<string, { id: number; name: string }[]>>({})
 
 async function fetchMembers() {
     if (!props.lab) return
-    const res = await authorizedFetch(`/labs/${props.lab.id}/members`)
+    const res = await apiFetch(`/labs/${props.lab.id}/members`)
     if (!res.ok) return
     const data = (await res.json()) as MemberResponse[]
     const map: Record<string, { id: number; name: string }[]> = {}

--- a/slice-guard/shared/db/lab.ts
+++ b/slice-guard/shared/db/lab.ts
@@ -37,6 +37,7 @@ export enum LabPermission {
     REMOVE_USER = 1 << 2,
     DELETE_LAB = 1 << 3,
     CREATE_REQUEST = 1 << 4,
-    READ = 1 << 5,
-    WRITE = 1 << 6,
+    MANAGE_REQUESTS = 1 << 5,
+    READ = 1 << 6,
+    WRITE = 1 << 7,
 }

--- a/slice-guard/shared/db/lab.ts
+++ b/slice-guard/shared/db/lab.ts
@@ -40,4 +40,8 @@ export enum LabPermission {
     MANAGE_REQUESTS = 1 << 5,
     READ = 1 << 6,
     WRITE = 1 << 7,
+    /**
+     * Grants every permission regardless of explicit role entries.
+     */
+    ALL = 1 << 30,
 }

--- a/slice-guard/shared/db/request.ts
+++ b/slice-guard/shared/db/request.ts
@@ -5,6 +5,7 @@ export interface PrintRequest {
     description?: string | null;
     file_path: string;
     metadata: unknown;
+    is_closed: boolean;
     created_at: Date;
 }
 

--- a/slice-guard/shared/db/request.ts
+++ b/slice-guard/shared/db/request.ts
@@ -3,7 +3,7 @@ export interface PrintRequest {
     lab_id: number;
     user_id: number;
     description?: string | null;
-    file_path: string;
+    file_data: Uint8Array;
     metadata: unknown;
     is_closed: boolean;
     created_at: Date;

--- a/slice-guard/shared/payloads/request.ts
+++ b/slice-guard/shared/payloads/request.ts
@@ -27,3 +27,7 @@ export interface RequestAssignTagPayload {
   tagId: number
   assign: boolean
 }
+
+export interface RequestStateUpdatePayload {
+  isClosed: boolean
+}


### PR DESCRIPTION
## Summary
- reorganize lab HTTP routes into dedicated files
- add MANAGE_REQUESTS permission and new DB helpers
- update print request list to respect permissions
- expose tag listing endpoint
- improve router guards and auth pages
- scaffold print request list UI and development tools

## Testing
- `npm run test` *(fails: bun runtime usage requires packages; network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_688181769ec083209953b2e713da6da6