### PR TITLE
Add consolidated database schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ The backend will be available on `http://localhost:3000` and the frontend on
 `http://localhost:5173`. The frontend is configured to talk to the backend using
 those internal addresses so WebSocket connections work out of the box.
 
+## Database Schema
+
+Complete schema files are provided under `slice-guard/backend/schema`. These
+SQL files combine all migrations so a new database can be created without
+running each migration individually.
+
+
 # Developmental Preview Images
 
 ## Jul 24th Update

--- a/slice-guard/backend/schema/auth.sql
+++ b/slice-guard/backend/schema/auth.sql
@@ -1,0 +1,24 @@
+CREATE SCHEMA IF NOT EXISTS auth;
+
+CREATE TABLE auth.users (
+    id SERIAL PRIMARY KEY,
+    email TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    name TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE auth.refresh_tokens (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES auth.users(id) ON DELETE CASCADE,
+    token TEXT UNIQUE NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    expires_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE auth.api_keys (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    key TEXT UNIQUE NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);

--- a/slice-guard/backend/schema/lab.sql
+++ b/slice-guard/backend/schema/lab.sql
@@ -1,0 +1,61 @@
+CREATE SCHEMA IF NOT EXISTS lab;
+
+CREATE TABLE lab.labs (
+    id SERIAL PRIMARY KEY,
+    owner_id INTEGER NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT,
+    image_url TEXT,
+    default_role_id INTEGER,
+    created_at TIMESTAMP DEFAULT NOW(),
+    CONSTRAINT labs_default_role_fkey FOREIGN KEY (default_role_id)
+        REFERENCES lab.roles(id) ON DELETE SET NULL
+);
+
+CREATE TABLE lab.roles (
+    id SERIAL PRIMARY KEY,
+    lab_id INTEGER NOT NULL REFERENCES lab.labs(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    permissions BIGINT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE lab.members (
+    lab_id INTEGER NOT NULL REFERENCES lab.labs(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    joined_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (lab_id, user_id)
+);
+
+CREATE TABLE lab.member_roles (
+    lab_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    role_id INTEGER NOT NULL REFERENCES lab.roles(id) ON DELETE CASCADE,
+    PRIMARY KEY (lab_id, user_id, role_id),
+    FOREIGN KEY (lab_id, user_id) REFERENCES lab.members(lab_id, user_id) ON DELETE CASCADE
+);
+
+CREATE TABLE lab.print_requests (
+    id SERIAL PRIMARY KEY,
+    lab_id INTEGER NOT NULL REFERENCES lab.labs(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    file_data BYTEA NOT NULL DEFAULT ''::bytea,
+    metadata JSONB NOT NULL,
+    description TEXT,
+    is_closed BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE lab.request_tags (
+    id SERIAL PRIMARY KEY,
+    lab_id INTEGER NOT NULL REFERENCES lab.labs(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    is_default BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE lab.request_tag_assignments (
+    request_id INTEGER NOT NULL REFERENCES lab.print_requests(id) ON DELETE CASCADE,
+    tag_id INTEGER NOT NULL REFERENCES lab.request_tags(id) ON DELETE CASCADE,
+    PRIMARY KEY (request_id, tag_id)
+);


### PR DESCRIPTION
## Summary
- generate `auth.sql` and `lab.sql` under backend/schema
- document the new schema files in README

## Testing
- `cd slice-guard/backend && bun test`

------
https://chatgpt.com/codex/tasks/task_e_6887e06ebfbc83208e6ddd599426fb8d