### PR TITLE
Implement colored tags and request titles

### DIFF
--- a/slice-guard/backend/schema/lab.sql
+++ b/slice-guard/backend/schema/lab.sql
@@ -39,6 +39,7 @@ CREATE TABLE lab.print_requests (
     id SERIAL PRIMARY KEY,
     lab_id INTEGER NOT NULL REFERENCES lab.labs(id) ON DELETE CASCADE,
     user_id INTEGER NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    title TEXT,
     file_data BYTEA NOT NULL DEFAULT ''::bytea,
     metadata JSONB NOT NULL,
     description TEXT,
@@ -50,6 +51,7 @@ CREATE TABLE lab.request_tags (
     id SERIAL PRIMARY KEY,
     lab_id INTEGER NOT NULL REFERENCES lab.labs(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
+    color TEXT NOT NULL DEFAULT '#9ca3af',
     is_default BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP DEFAULT NOW()
 );

--- a/slice-guard/backend/schema/migrations/008_tag_color_title.sql
+++ b/slice-guard/backend/schema/migrations/008_tag_color_title.sql
@@ -1,0 +1,5 @@
+ALTER TABLE lab.print_requests
+    ADD COLUMN title TEXT;
+
+ALTER TABLE lab.request_tags
+    ADD COLUMN color TEXT NOT NULL DEFAULT '#9ca3af';

--- a/slice-guard/backend/src/db/request.ts
+++ b/slice-guard/backend/src/db/request.ts
@@ -27,12 +27,13 @@ export async function createPrintRequest(
     userId: number,
     fileData: Buffer,
     metadata: unknown,
+    title: string,
     description: string | null = null,
 ): Promise<PrintRequestRow> {
     const rows: PrintRequestRow[] = await db`
-        INSERT INTO lab.print_requests (lab_id, user_id, file_data, metadata, description)
-             VALUES (${labId}, ${userId}, ${fileData}, ${JSON.stringify(metadata)}, ${description})
-        RETURNING id, lab_id, user_id, file_data, metadata, description, is_closed, created_at
+        INSERT INTO lab.print_requests (lab_id, user_id, title, file_data, metadata, description)
+             VALUES (${labId}, ${userId}, ${title}, ${fileData}, ${JSON.stringify(metadata)}, ${description})
+        RETURNING id, lab_id, user_id, title, file_data, metadata, description, is_closed, created_at
     `;
     return normalizeRequest(rows[0]);
 }
@@ -43,7 +44,7 @@ export async function getUserPrintRequests(
     userId: number
 ): Promise<PrintRequestRow[]> {
     const rows: PrintRequestRow[] = await db`
-        SELECT id, lab_id, user_id, file_data, metadata, description, is_closed, created_at
+        SELECT id, lab_id, user_id, title, file_data, metadata, description, is_closed, created_at
           FROM lab.print_requests
          WHERE lab_id = ${labId} AND user_id = ${userId}
     `;
@@ -54,12 +55,13 @@ export async function createTag(
     db: SQL,
     labId: number,
     name: string,
+    color: string,
     isDefault = false
 ): Promise<RequestTagRow> {
     const rows: RequestTagRow[] = await db`
-        INSERT INTO lab.request_tags (lab_id, name, is_default)
-             VALUES (${labId}, ${name}, ${isDefault})
-        RETURNING id, lab_id, name, is_default, created_at
+        INSERT INTO lab.request_tags (lab_id, name, color, is_default)
+             VALUES (${labId}, ${name}, ${color}, ${isDefault})
+        RETURNING id, lab_id, name, color, is_default, created_at
     `;
     return normalizeTag(rows[0]);
 }
@@ -73,7 +75,7 @@ export async function setTagDefault(
         UPDATE lab.request_tags
            SET is_default = ${isDefault}
          WHERE id = ${tagId}
-        RETURNING id, lab_id, name, is_default, created_at
+        RETURNING id, lab_id, name, color, is_default, created_at
     `;
     return normalizeTag(rows[0]);
 }
@@ -106,7 +108,7 @@ export async function getTagsForRequest(
     requestId: number
 ): Promise<RequestTagRow[]> {
     const rows: RequestTagRow[] = await db`
-        SELECT t.id, t.lab_id, t.name, t.is_default, t.created_at
+        SELECT t.id, t.lab_id, t.name, t.color, t.is_default, t.created_at
           FROM lab.request_tag_assignments a
           JOIN lab.request_tags t ON a.tag_id = t.id
          WHERE a.request_id = ${requestId}
@@ -119,7 +121,7 @@ export async function getAllPrintRequests(
     labId: number,
 ): Promise<PrintRequestRow[]> {
     const rows: PrintRequestRow[] = await db`
-        SELECT id, lab_id, user_id, file_data, metadata, description, is_closed, created_at
+        SELECT id, lab_id, user_id, title, file_data, metadata, description, is_closed, created_at
           FROM lab.print_requests
          WHERE lab_id = ${labId}
     `;
@@ -131,7 +133,7 @@ export async function listTags(
     labId: number,
 ): Promise<RequestTagRow[]> {
     const rows: RequestTagRow[] = await db`
-        SELECT id, lab_id, name, is_default, created_at
+        SELECT id, lab_id, name, color, is_default, created_at
           FROM lab.request_tags
          WHERE lab_id = ${labId}
     `;
@@ -143,7 +145,7 @@ export async function getPrintRequestById(
     requestId: number,
 ): Promise<PrintRequestRow | null> {
     const rows: PrintRequestRow[] = await db`
-        SELECT id, lab_id, user_id, file_data, metadata, description, is_closed, created_at
+        SELECT id, lab_id, user_id, title, file_data, metadata, description, is_closed, created_at
           FROM lab.print_requests
          WHERE id = ${requestId}
     `;
@@ -159,7 +161,7 @@ export async function setRequestClosed(
         UPDATE lab.print_requests
            SET is_closed = ${isClosed}
          WHERE id = ${requestId}
-        RETURNING id, lab_id, user_id, file_data, metadata, description, is_closed, created_at
+        RETURNING id, lab_id, user_id, title, file_data, metadata, description, is_closed, created_at
     `;
     return normalizeRequest(rows[0]);
 }

--- a/slice-guard/backend/src/http/request.ts
+++ b/slice-guard/backend/src/http/request.ts
@@ -31,7 +31,7 @@ import type {
  */
 export const create = withAuth(async (req, userId, state, params) => {
     const labId = Number(params.labId);
-    const { file, metadata, description } = await req.json() as RequestCreatePayload;
+    const { file, metadata, title, description } = await req.json() as RequestCreatePayload;
 
     state.logger.debug({ labId, userId }, 'Creating print request');
     const perms = await getMemberRolePermissions(state.db, labId, userId);
@@ -41,7 +41,7 @@ export const create = withAuth(async (req, userId, state, params) => {
 
     const buffer = Buffer.from(file, 'base64');
     const compressed = compressRequestFile(buffer);
-    const result = await createPrintRequest(state.db, labId, userId, compressed, metadata, description ?? null);
+    const result = await createPrintRequest(state.db, labId, userId, compressed, metadata, title, description ?? null);
     state.logger.debug({ id: result.id }, 'Created print request');
     return Response.json(result);
 });
@@ -98,13 +98,13 @@ export const getRoute = withAuth(async (_req, userId, state, params) => {
  */
 export const createTagRoute = withAuth(async (req, userId, state, params) => {
     const labId = Number(params.labId);
-    const { name, isDefault } = await req.json() as TagCreatePayload;
+    const { name, color, isDefault } = await req.json() as TagCreatePayload;
 
     const perms = await getMemberRolePermissions(state.db, labId, userId);
     if (!hasLabPermission(perms, LabPermission.MANAGE_ROLES))
         return new Response('Unauthorized', { status: 403 });
-    state.logger.debug({ labId, name }, 'Creating tag');
-    const tag = await createTag(state.db, labId, name, isDefault ?? false);
+    state.logger.debug({ labId, name, color }, 'Creating tag');
+    const tag = await createTag(state.db, labId, name, color, isDefault ?? false);
     state.logger.debug({ id: tag.id }, 'Created tag');
     return Response.json(tag);
 });

--- a/slice-guard/backend/tests/request.test.ts
+++ b/slice-guard/backend/tests/request.test.ts
@@ -32,6 +32,7 @@ function sampleRequest(): PrintRequestRow {
     id: 1,
     lab_id: 1,
     user_id: 2,
+    title: "Title",
     file_data: new Uint8Array([1, 2, 3]),
     metadata: { a: 1 },
     description: "desc",
@@ -45,6 +46,7 @@ function sampleTag(): RequestTagRow {
     id: 1,
     lab_id: 1,
     name: "Pending",
+    color: "#fff",
     is_default: false,
     created_at: new Date(),
   };
@@ -53,11 +55,11 @@ function sampleTag(): RequestTagRow {
 test("createPrintRequest inserts expected values", async () => {
   const req = sampleRequest();
   const db = createMockSQL([req]);
-  const result = await createPrintRequest(db as any, req.lab_id, req.user_id, req.file_data as any, req.metadata, req.description!);
+  const result = await createPrintRequest(db as any, req.lab_id, req.user_id, req.file_data as any, req.metadata, req.title, req.description!);
   expect(normalize(db.lastQuery)).toBe(
-    "INSERT INTO lab.print_requests (lab_id, user_id, file_data, metadata, description) VALUES ($1, $2, $3, $4, $5) RETURNING id, lab_id, user_id, file_data, metadata, description, is_closed, created_at"
+    "INSERT INTO lab.print_requests (lab_id, user_id, title, file_data, metadata, description) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id, lab_id, user_id, title, file_data, metadata, description, is_closed, created_at"
   );
-  expect(db.lastParams).toEqual([req.lab_id, req.user_id, req.file_data, JSON.stringify(req.metadata), req.description]);
+  expect(db.lastParams).toEqual([req.lab_id, req.user_id, req.title, req.file_data, JSON.stringify(req.metadata), req.description]);
   expect(result).toEqual(req);
 });
 
@@ -66,7 +68,7 @@ test("getUserPrintRequests selects expected", async () => {
   const db = createMockSQL([req]);
   const result = await getUserPrintRequests(db as any, req.lab_id, req.user_id);
   expect(normalize(db.lastQuery)).toBe(
-    "SELECT id, lab_id, user_id, file_data, metadata, description, is_closed, created_at FROM lab.print_requests WHERE lab_id = $1 AND user_id = $2"
+    "SELECT id, lab_id, user_id, title, file_data, metadata, description, is_closed, created_at FROM lab.print_requests WHERE lab_id = $1 AND user_id = $2"
   );
   expect(db.lastParams).toEqual([req.lab_id, req.user_id]);
   expect(result).toEqual([req]);
@@ -75,11 +77,11 @@ test("getUserPrintRequests selects expected", async () => {
 test("createTag inserts expected values", async () => {
   const tag = sampleTag();
   const db = createMockSQL([tag]);
-  const result = await createTag(db as any, tag.lab_id, tag.name, tag.is_default);
+  const result = await createTag(db as any, tag.lab_id, tag.name, tag.color, tag.is_default);
   expect(normalize(db.lastQuery)).toBe(
-    "INSERT INTO lab.request_tags (lab_id, name, is_default) VALUES ($1, $2, $3) RETURNING id, lab_id, name, is_default, created_at"
+    "INSERT INTO lab.request_tags (lab_id, name, color, is_default) VALUES ($1, $2, $3, $4) RETURNING id, lab_id, name, color, is_default, created_at"
   );
-  expect(db.lastParams).toEqual([tag.lab_id, tag.name, tag.is_default]);
+  expect(db.lastParams).toEqual([tag.lab_id, tag.name, tag.color, tag.is_default]);
   expect(result).toEqual(tag);
 });
 
@@ -88,7 +90,7 @@ test("setTagDefault updates flag", async () => {
   const db = createMockSQL([tag]);
   const result = await setTagDefault(db as any, tag.id, true);
   expect(normalize(db.lastQuery)).toBe(
-    "UPDATE lab.request_tags SET is_default = $1 WHERE id = $2 RETURNING id, lab_id, name, is_default, created_at"
+    "UPDATE lab.request_tags SET is_default = $1 WHERE id = $2 RETURNING id, lab_id, name, color, is_default, created_at"
   );
   expect(db.lastParams).toEqual([true, tag.id]);
   expect(result).toEqual(tag);
@@ -117,7 +119,7 @@ test("getTagsForRequest selects join", async () => {
   const db = createMockSQL([tag]);
   const result = await getTagsForRequest(db as any, 1);
   expect(normalize(db.lastQuery)).toBe(
-    "SELECT t.id, t.lab_id, t.name, t.is_default, t.created_at FROM lab.request_tag_assignments a JOIN lab.request_tags t ON a.tag_id = t.id WHERE a.request_id = $1"
+    "SELECT t.id, t.lab_id, t.name, t.color, t.is_default, t.created_at FROM lab.request_tag_assignments a JOIN lab.request_tags t ON a.tag_id = t.id WHERE a.request_id = $1"
   );
   expect(db.lastParams).toEqual([1]);
   expect(result).toEqual([tag]);

--- a/slice-guard/frontend/src/components/Dropdown.vue
+++ b/slice-guard/frontend/src/components/Dropdown.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, useSlots } from 'vue'
 
 interface DropdownOption {
   id: number | string
@@ -26,6 +26,7 @@ const emit = defineEmits<Emits>()
 
 const isOpen = ref(false)
 const dropdownRef = ref<HTMLElement>()
+const slots = useSlots()
 
 // Handle click outside to close dropdown
 function handleClickOutside(event: MouseEvent) {
@@ -103,7 +104,13 @@ const selectClass = "bg-surface-low px-3 py-1 rounded-full text-fg-primary shado
 
 <template>
   <div class="relative" ref="dropdownRef">
+    <template v-if="$slots.activator">
+      <div @click="isOpen = !isOpen">
+        <slot name="activator" />
+      </div>
+    </template>
     <button
+      v-else
       @click="isOpen = !isOpen"
       :class="selectClass"
       class="flex items-center justify-between gap-2 w-full"

--- a/slice-guard/frontend/src/styles/main.css
+++ b/slice-guard/frontend/src/styles/main.css
@@ -44,11 +44,11 @@
   /*
   * Surface colors
   */
-  --color-surface-lowest: #fffdfc;
-  --color-surface-low: #FCFCFC;
-  --color-surface: #F2F0F0;
-  --color-surface-high: #e5e5ea;
-  --color-surface-highest: #d1d1d6;
+  --color-surface-lowest: #f5f5f5;
+  --color-surface-low: #e8e8e8;
+  --color-surface: #bcbcbc;
+  --color-surface-high: #909090;
+  --color-surface-highest: #4f4f4f;
 
   /**
   * Text colors
@@ -80,4 +80,9 @@
   --color-fg-quaternary: #ebebf52d;
   --color-fg-inverse: #000000e6;
   --color-fg-accent: #0a84ff;
+}
+
+html {
+  overflow-y: scroll; /* Force scrollbar to always be present */
+  scrollbar-gutter: stable;
 }

--- a/slice-guard/frontend/src/views/lab/LabDashboard.vue
+++ b/slice-guard/frontend/src/views/lab/LabDashboard.vue
@@ -53,10 +53,12 @@ async function createMockRequest() {
     <div class="mt-6 space-y-2">
         <h2 class="text-fg-primary font-semibold">Dev Tools</h2>
         <div class="flex gap-2 items-center">
-            <input v-model="tagName" placeholder="Tag name" class="bg-surface-low px-2 py-1 rounded-md" />
-            <button @click="createTag" class="bg-salem-800 text-white px-2 py-1 rounded-md">Create Tag</button>
+            <input v-model="tagName" placeholder="Tag name"
+                class="bg-surface-low px-2 py-1 rounded-md text-fg-primary" />
+            <button @click="createTag" class="bg-salem-800 text-fg-primary px-2 py-1 rounded-md">Create Tag</button>
         </div>
-        <button @click="createMockRequest" class="bg-surface-low px-2 py-1 rounded-md">Create Mock Request</button>
+        <button @click="createMockRequest" class="bg-surface-low px-2 py-1 rounded-md text-fg-primary">Create Mock
+            Request</button>
     </div>
 
 </template>

--- a/slice-guard/frontend/src/views/lab/LabDashboard.vue
+++ b/slice-guard/frontend/src/views/lab/LabDashboard.vue
@@ -2,6 +2,7 @@
 import ThemeToggle from '../../components/ThemeToggle.vue';
 import { ref } from 'vue'
 import { apiFetch } from '../../services/api'
+import Button from "../../components/Button.vue";
 
 interface Props {
     lab: any | null
@@ -33,7 +34,6 @@ async function createMockRequest() {
 }
 
 
-
 </script>
 
 <template>
@@ -55,10 +55,18 @@ async function createMockRequest() {
         <div class="flex gap-2 items-center">
             <input v-model="tagName" placeholder="Tag name"
                 class="bg-surface-low px-2 py-1 rounded-md text-fg-primary" />
-            <button @click="createTag" class="bg-salem-800 text-fg-primary px-2 py-1 rounded-md">Create Tag</button>
+            <button @click="createTag" class="bg-salem-800 text-white px-2 py-1 rounded-md">Create Tag</button>
         </div>
         <button @click="createMockRequest" class="bg-surface-low px-2 py-1 rounded-md text-fg-primary">Create Mock
             Request</button>
+    </div>
+
+    <!-- Testing for theme -->
+    <div class="flex flex-row gap-2 mt-6">
+        <Button v-for="entry in ['surface-lowest', 'surface-low', 'surface', 'surface-high', 'surface-highest']"
+            :key="entry" :class="`bg-${entry}`" class="drop-shadow-md">
+            <span class=" text-fg-primary"> Foo bar </span>
+        </Button>
     </div>
 
 </template>

--- a/slice-guard/frontend/src/views/lab/LabLayout.vue
+++ b/slice-guard/frontend/src/views/lab/LabLayout.vue
@@ -33,13 +33,12 @@ watch(() => route.params.id, fetchLab)
 
 <template>
   <div class="flex min-h-screen bg-surface-lowest">
-    <aside
-      class="w-56 lg:w-64 xl:w-72 bg-surface-low min-h-screen p-7 shrink-0 rounded-r-4xl shadow-inner shadow-surface-high">
+    <aside class="w-56 lg:w-64 xl:w-72 bg-surface-low min-h-screen p-7 shrink-0 rounded-r-3xl border-r border-surface">
       <Sidebar :lab="lab" />
     </aside>
 
     <!-- Main content area -->
-    <div class="bg-surface-lowest w-full flex gap-0">
+    <div class="bg-surface-lowest w-full flex gap-0 overflow-y-scroll">
       <div class="p-6 flex-1 w-full">
         <!-- Actual insert content-->
         <router-view :lab="lab" :error="error" :loading="loading" />

--- a/slice-guard/frontend/src/views/lab/print_requests/LabPrintRequests.vue
+++ b/slice-guard/frontend/src/views/lab/print_requests/LabPrintRequests.vue
@@ -90,44 +90,84 @@ const selectClass = "bg-surface-low px-2 py-1 rounded-md text-fg-primary"
     <!-- The search bar. Spans the entire width of the element and allows you to easily search many things -->
     <div class="w-full bg-surface-low rounded-lg px-3 py-2 flex items-center gap-2">
       <svg class="h-5 w-5 text-fg-secondary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
       </svg>
 
-      <input
-        v-model="search"
-        placeholder="Search requests, users, descriptions..."
-        class="flex-1 bg-transparent text-fg-primary placeholder-fg-secondary outline-none"
-      />
+      <input v-model="search" placeholder="Search requests, users, descriptions..."
+        class="flex-1 bg-transparent text-fg-primary placeholder-fg-secondary outline-none" />
     </div>
 
     <div class="flex flex-wrap gap-2 items-center">
 
-      <Dropdown
-        v-model="tagFilter"
-        :options="tagOptions"
-        placeholder="All Tags"
-        :multiple="true"
-      />
+      <Dropdown v-model="tagFilter" :options="tagOptions" placeholder="All Tags" :multiple="true" />
 
       <input type="date" v-model="from" :class="selectClass" />
       <input type="date" v-model="to" :class="selectClass" />
 
-      <Dropdown
-        v-model="stateFilter"
-        :options="[
-          { id: 'all', name: 'All' },
-          { id: 'open', name: 'Open' },
-          { id: 'closed', name: 'Closed' }
-        ]"
-        placeholder="All States"
-        :multiple="false"
-      />
+      <Dropdown v-model="stateFilter" :options="[
+        { id: 'all', name: 'All' },
+        { id: 'open', name: 'Open' },
+        { id: 'closed', name: 'Closed' }
+      ]" placeholder="All States" :multiple="false" />
     </div>
 
-    <div class="grid grid-cols-auto gap-5">
-      <div v-for="item in filtered" :key="item.request.id">
-        <PrintRequestListItem :entry="item" />
-      </div>
-    </div>
+    <TransitionGroup ref="gridRef" name="grid" tag="div" :class="[
+      'grid gap-5 auto-rows-fr transition-all duration-300',
+      'grid-cols-1 lg:grid-cols-2 xl:grid-cols-3'
+    ]">
+      <PrintRequestListItem v-for="(item, index) in filtered" :key="item.request.id" :entry="item" class="
+        grid-item transition-all duration-300" :style="{
+          transitionDelay: `${index * 70}ms`
+        }" />
+    </TransitionGroup>
   </div>
 </template>
+
+<style scoped>
+.grid-item {
+  transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  will-change: transform, opacity;
+  /* Add these to prevent stretching */
+  max-width: 100%;
+  min-height: 200px;
+  /* Set a reasonable minimum height */
+  height: fit-content;
+  box-sizing: border-box;
+}
+
+/* Smoother grid resizing */
+.grid-resizing .grid-item {
+  transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1) !important;
+  max-width: 100% !important;
+}
+
+.grid-item.resizing {
+  transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+
+/* Smoother animations */
+.grid-move {
+  transition: all 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.grid-enter-active {
+  transition: all 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.grid-leave-active {
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: absolute;
+  z-index: -1;
+}
+
+/* More subtle enter/leave effects */
+.grid-enter-from {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+.grid-leave-to {
+  opacity: 0;
+}
+</style>

--- a/slice-guard/frontend/src/views/lab/print_requests/PrintRequestListItem.vue
+++ b/slice-guard/frontend/src/views/lab/print_requests/PrintRequestListItem.vue
@@ -66,7 +66,7 @@ const tagOptions = computed(() => allTags.value.map(t => ({ id: t.id, name: t.na
 </script>
 
 <template>
-  <div class="bg-surface-low shadow-sm rounded-md max-w-72 p-3 space-y-2">
+  <div class="bg-surface-low shadow-xs shadow-surface-high rounded-xl w-full p-3 flex flex-col gap-2">
     <!-- Title and user avatar -->
     <div class="flex flex-row items-center justify-between">
       <!-- Title -->
@@ -109,7 +109,7 @@ const tagOptions = computed(() => allTags.value.map(t => ({ id: t.id, name: t.na
     </div>
 
     <!-- Action buttons -->
-    <div class="flex flex-row gap-2 items-center">
+    <div class="flex flex-row gap-2 items-center mt-auto">
       <Dropdown v-model="statusModel" :options="statusOptions" placeholder="Status" />
 
       <Dropdown v-model="tagIds" :options="tagOptions" :multiple="true">

--- a/slice-guard/frontend/src/views/lab/print_requests/PrintRequestListItem.vue
+++ b/slice-guard/frontend/src/views/lab/print_requests/PrintRequestListItem.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { type RequestItem } from './LabPrintRequests.vue';
-import { computed } from 'vue';
+import { computed, ref, onMounted, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useAuthStore } from '../../../store/auth';
+import Dropdown from '../../../components/Dropdown.vue';
+import { apiFetch } from '../../../services/api';
+import type { RequestTag } from '@shared/db/request';
 
 interface Props {
   entry: RequestItem
@@ -14,6 +17,51 @@ const route = useRoute();
 const auth = useAuthStore();
 
 const labId = computed(() => Number(route.params.id));
+
+const statusOptions = [
+  { id: 'open', name: 'Open' },
+  { id: 'closed', name: 'Closed' }
+];
+
+const statusModel = ref(entry.request.is_closed ? 'closed' : 'open');
+
+const allTags = ref<RequestTag[]>([]);
+const tagIds = ref<(number | string)[]>(entry.tags.map(t => t.id));
+
+async function fetchTags() {
+  const res = await apiFetch(`/labs/${labId.value}/tags`);
+  if (res.ok) allTags.value = await res.json();
+}
+
+onMounted(fetchTags);
+
+watch(statusModel, async (val) => {
+  await apiFetch(`/labs/${labId.value}/requests/${entry.request.id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ isClosed: val === 'closed' })
+  });
+  entry.request.is_closed = val === 'closed';
+});
+
+watch(tagIds, async (val, old) => {
+  const added = (val as number[]).filter(id => !(old as number[]).includes(id));
+  const removed = (old as number[]).filter(id => !(val as number[]).includes(id));
+  for (const id of added) {
+    await apiFetch(`/labs/${labId.value}/requests/${entry.request.id}/tags/${id}`, {
+      method: 'POST',
+      body: JSON.stringify({ assign: true })
+    });
+  }
+  for (const id of removed) {
+    await apiFetch(`/labs/${labId.value}/requests/${entry.request.id}/tags/${id}`, {
+      method: 'POST',
+      body: JSON.stringify({ assign: false })
+    });
+  }
+  entry.tags = allTags.value.filter(t => (val as number[]).includes(t.id));
+});
+
+const tagOptions = computed(() => allTags.value.map(t => ({ id: t.id, name: t.name })));
 </script>
 
 <template>
@@ -22,7 +70,7 @@ const labId = computed(() => Number(route.params.id));
     <div class="flex flex-row items-center justify-between">
       <!-- Title -->
       <h3 class="text-fg-primary font-medium text-md truncate text-pretty line-clamp-2 max-w-[80%]">
-        This is an example title that should be truncated and is super duper long
+        {{ entry.request.title }}
       </h3>
 
       <!-- User avatar display. TODO: Actual user avatars -->
@@ -48,9 +96,13 @@ const labId = computed(() => Number(route.params.id));
           Date(entry.request.created_at).toLocaleTimeString() }}
       </div>
 
-      <!-- TODO: Tags of this request, each one being a pill and using the HEX code of the tag and its name -->
-      <div>
-
+      <div class="flex flex-wrap gap-1">
+        <span
+          v-for="tag in entry.tags"
+          :key="tag.id"
+          class="px-2 py-0.5 rounded-full text-xs text-white"
+          :style="{ backgroundColor: tag.color }"
+        >{{ tag.name }}</span>
       </div>
     </div>
 
@@ -60,13 +112,26 @@ const labId = computed(() => Number(route.params.id));
     </div>
 
     <!-- Action buttons -->
-    <div class="flex flex-row gap-2">
-      <!-- Dropdown to change the status of this ticket - closed, open, etc -->
-      <!-- TODO use custom dropdown component -->
+    <div class="flex flex-row gap-2 items-center">
+      <Dropdown
+        v-model="statusModel"
+        :options="statusOptions"
+        placeholder="Status"
+      />
 
-      <!-- Dropdown to assign tags to this request -->
-      <!-- TODO use custom dropdown component for tag edits, select and unselect tags.
-        Additionally, update the tags to have a custom HEX code that it used to help display colors easier. -->
+      <Dropdown
+        v-model="tagIds"
+        :options="tagOptions"
+        :multiple="true"
+      >
+        <template #activator>
+          <div class="w-6 h-6 rounded-full bg-surface-high flex items-center justify-center cursor-pointer">
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+            </svg>
+          </div>
+        </template>
+      </Dropdown>
     </div>
   </div>
 </template>

--- a/slice-guard/frontend/src/views/lab/print_requests/PrintRequestListItem.vue
+++ b/slice-guard/frontend/src/views/lab/print_requests/PrintRequestListItem.vue
@@ -11,7 +11,8 @@ interface Props {
   entry: RequestItem
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
+const entry = props.entry;
 
 const route = useRoute();
 const auth = useAuthStore();
@@ -70,11 +71,11 @@ const tagOptions = computed(() => allTags.value.map(t => ({ id: t.id, name: t.na
     <div class="flex flex-row items-center justify-between">
       <!-- Title -->
       <h3 class="text-fg-primary font-medium text-md truncate text-pretty line-clamp-2 max-w-[80%]">
-        {{ entry.request.title }}
+        {{ entry.request.title || "[No title given]" }}
       </h3>
 
       <!-- User avatar display. TODO: Actual user avatars -->
-      <div class="w-8 h-8 bg-gray-300 rounded-full flex items-center justify-center text-xs text-fg-secondary">
+      <div class="w-8 h-8 bg-gray-300 rounded-full flex items-center justify-center text-xs text-salem-800">
         {{ entry.user?.name?.charAt(0) || '?' }}
       </div>
     </div>
@@ -97,12 +98,8 @@ const tagOptions = computed(() => allTags.value.map(t => ({ id: t.id, name: t.na
       </div>
 
       <div class="flex flex-wrap gap-1">
-        <span
-          v-for="tag in entry.tags"
-          :key="tag.id"
-          class="px-2 py-0.5 rounded-full text-xs text-white"
-          :style="{ backgroundColor: tag.color }"
-        >{{ tag.name }}</span>
+        <span v-for="tag in entry.tags" :key="tag.id" class="px-2 py-0.5 rounded-full text-xs text-white"
+          :style="{ backgroundColor: tag.color }">{{ tag.name }}</span>
       </div>
     </div>
 
@@ -113,17 +110,9 @@ const tagOptions = computed(() => allTags.value.map(t => ({ id: t.id, name: t.na
 
     <!-- Action buttons -->
     <div class="flex flex-row gap-2 items-center">
-      <Dropdown
-        v-model="statusModel"
-        :options="statusOptions"
-        placeholder="Status"
-      />
+      <Dropdown v-model="statusModel" :options="statusOptions" placeholder="Status" />
 
-      <Dropdown
-        v-model="tagIds"
-        :options="tagOptions"
-        :multiple="true"
-      >
+      <Dropdown v-model="tagIds" :options="tagOptions" :multiple="true">
         <template #activator>
           <div class="w-6 h-6 rounded-full bg-surface-high flex items-center justify-center cursor-pointer">
             <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/slice-guard/shared/db/request.ts
+++ b/slice-guard/shared/db/request.ts
@@ -2,6 +2,7 @@ export interface PrintRequest {
     id: number;
     lab_id: number;
     user_id: number;
+    title?: string | null;
     description?: string | null;
     file_data: Uint8Array;
     metadata: unknown;
@@ -13,6 +14,7 @@ export interface RequestTag {
     id: number;
     lab_id: number;
     name: string;
+    color: string;
     is_default: boolean;
     created_at: Date;
 }

--- a/slice-guard/shared/payloads/request.ts
+++ b/slice-guard/shared/payloads/request.ts
@@ -4,6 +4,7 @@ export interface RequestCreatePayload {
   labId: number
   file: string
   metadata: any
+  title: string
   description?: string
 }
 
@@ -14,6 +15,7 @@ export interface RequestListPayload {
 export interface TagCreatePayload {
   labId: number
   name: string
+  color: string
   isDefault?: boolean
 }
 


### PR DESCRIPTION
## Summary
- support title on print requests and color on tags
- add migration for the new columns
- expose new columns in database helpers and API routes
- extend Dropdown component with an activator slot
- show colored tags and status control in PrintRequestListItem
- update tests to match new SQL

## Testing
- `bun test` in backend
- `bun run build` in frontend

------
https://chatgpt.com/codex/tasks/task_e_688d304ce2d88320a198129a10e0c911