### PR TITLE
feat: animate tag addition

### DIFF
--- a/slice-guard/frontend/src/views/lab/print_requests/PrintRequestListItem.vue
+++ b/slice-guard/frontend/src/views/lab/print_requests/PrintRequestListItem.vue
@@ -108,38 +108,22 @@ const tagOptions = computed(() =>
         {{ new Date(entry.request.created_at).toLocaleTimeString() }}
       </div>
 
-      <TransitionGroup
-        appear
-        name="tag-bubble"
-        tag="div"
-        class="flex flex-wrap gap-1 items-center justify-start"
-      >
-        <span
-          v-for="tag in entry.tags"
-          :key="tag.id"
-          class="px-2 h-5 rounded-full text-xs text-white flex items-center"
-          :style="{ backgroundColor: tag.color }"
-          >{{ tag.name }}
+      <TransitionGroup appear name="tag-bubble" tag="div" class="flex flex-wrap gap-1 items-center justify-start">
+        <span v-for="tag in entry.tags" :key="tag.id" class="px-2 h-5 rounded-full text-xs text-white flex items-center"
+          :style="{ backgroundColor: tag.color }">{{ tag.name }}
         </span>
 
         <!-- Add tag button -->
-        <Dropdown
-          :key="'add'"
-          v-model="tagIds"
-          :options="tagOptions"
-          :multiple="true"
-        >
+        <Dropdown :key="'add'" v-model="tagIds" :options="tagOptions" :multiple="true">
           <template #activator>
-            <PlusCircleIcon
-              class="h-5 w-5 text-surface-high drop-shadow-sm"
-            />
+            <PlusCircleIcon class="h-5 w-5 text-surface-high drop-shadow-sm" />
           </template>
         </Dropdown>
       </TransitionGroup>
     </div>
 
     <!-- Description of the ticket, max 3 lines, truncated -->
-  <div class="text-sm text-fg-secondary line-clamp-3 mt-auto text-pretty text-left">
+    <div class="text-sm text-fg-secondary line-clamp-3 mt-auto text-pretty text-left">
       {{ entry.request.description }}
     </div>
 
@@ -155,16 +139,23 @@ const tagOptions = computed(() =>
 .tag-bubble-leave-active {
   transition: all 0.2s ease;
 }
+
+.tag-bubble-leave-active {
+  position: absolute;
+}
+
 .tag-bubble-enter-from,
 .tag-bubble-leave-to {
   opacity: 0;
   transform: scale(0.8);
 }
+
 .tag-bubble-enter-to,
 .tag-bubble-leave-from {
   opacity: 1;
   transform: scale(1);
 }
+
 .tag-bubble-move {
   transition: transform 0.2s ease;
 }

--- a/slice-guard/frontend/src/views/lab/print_requests/PrintRequestListItem.vue
+++ b/slice-guard/frontend/src/views/lab/print_requests/PrintRequestListItem.vue
@@ -108,22 +108,38 @@ const tagOptions = computed(() =>
         {{ new Date(entry.request.created_at).toLocaleTimeString() }}
       </div>
 
-      <div class="flex flex-wrap gap-1 items-center justify-start">
-        <span v-for="tag in entry.tags" :key="tag.id" class="px-2 h-5 rounded-full text-xs text-white flex items-center"
-          :style="{ backgroundColor: tag.color }">{{ tag.name }}
+      <TransitionGroup
+        appear
+        name="tag-bubble"
+        tag="div"
+        class="flex flex-wrap gap-1 items-center justify-start"
+      >
+        <span
+          v-for="tag in entry.tags"
+          :key="tag.id"
+          class="px-2 h-5 rounded-full text-xs text-white flex items-center"
+          :style="{ backgroundColor: tag.color }"
+          >{{ tag.name }}
         </span>
 
         <!-- Add tag button -->
-        <Dropdown v-model="tagIds" :options="tagOptions" :multiple="true">
+        <Dropdown
+          :key="'add'"
+          v-model="tagIds"
+          :options="tagOptions"
+          :multiple="true"
+        >
           <template #activator>
-            <PlusCircleIcon class="h-5 w-5 text-surface-high drop-shadow-sm" />
+            <PlusCircleIcon
+              class="h-5 w-5 text-surface-high drop-shadow-sm"
+            />
           </template>
         </Dropdown>
-      </div>
+      </TransitionGroup>
     </div>
 
     <!-- Description of the ticket, max 3 lines, truncated -->
-    <div class="text-sm text-fg-secondary line-clamp-3 mt-auto text-pretty text-left">
+  <div class="text-sm text-fg-secondary line-clamp-3 mt-auto text-pretty text-left">
       {{ entry.request.description }}
     </div>
 
@@ -133,3 +149,23 @@ const tagOptions = computed(() =>
     </div>
   </div>
 </template>
+
+<style scoped>
+.tag-bubble-enter-active,
+.tag-bubble-leave-active {
+  transition: all 0.2s ease;
+}
+.tag-bubble-enter-from,
+.tag-bubble-leave-to {
+  opacity: 0;
+  transform: scale(0.8);
+}
+.tag-bubble-enter-to,
+.tag-bubble-leave-from {
+  opacity: 1;
+  transform: scale(1);
+}
+.tag-bubble-move {
+  transition: transform 0.2s ease;
+}
+</style>


### PR DESCRIPTION
## Summary
- animate tag addition and plus icon with friendly transition

## Testing
- `bun run test` (backend tests passed, frontend test script missing)


------
https://chatgpt.com/codex/tasks/task_e_6893794ad68883209494017e82a06f07