### PR TITLE
feat: add role management tab

### DIFF
--- a/slice-guard/backend/schema/lab.sql
+++ b/slice-guard/backend/schema/lab.sql
@@ -17,6 +17,7 @@ CREATE TABLE lab.roles (
     lab_id INTEGER NOT NULL REFERENCES lab.labs(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
     permissions BIGINT NOT NULL,
+    color TEXT,
     rank INTEGER NOT NULL DEFAULT 0,
     created_at TIMESTAMP DEFAULT NOW()
 );

--- a/slice-guard/backend/schema/migrations/013_role_color.sql
+++ b/slice-guard/backend/schema/migrations/013_role_color.sql
@@ -1,0 +1,3 @@
+-- Add optional color to lab roles for UI styling.
+ALTER TABLE lab.roles
+    ADD COLUMN IF NOT EXISTS color TEXT;

--- a/slice-guard/backend/src/db/lab/index.ts
+++ b/slice-guard/backend/src/db/lab/index.ts
@@ -3,8 +3,8 @@ import type { SQL } from 'bun';
 import { addMember } from './member';
 import { createRole } from './role';
 
-export interface LabRow extends Lab {}
-export interface LabRoleRow extends LabRole {}
+export type LabRow = Lab;
+export type LabRoleRow = LabRole;
 
 export * from './member';
 export * from './permissions';
@@ -44,6 +44,7 @@ export async function createLab(
         'everyone',
         LabPermission.READ | LabPermission.WRITE,
         0,
+        null,
     );
     await db`
         UPDATE lab.labs

--- a/slice-guard/backend/src/db/lab/member.ts
+++ b/slice-guard/backend/src/db/lab/member.ts
@@ -78,7 +78,7 @@ export async function getMemberRoles(
     userId: number,
 ): Promise<LabRoleRow[]> {
     const rows: LabRoleRow[] = await db`
-        SELECT r.id, r.lab_id, r.name, r.permissions, r.rank, r.created_at
+        SELECT r.id, r.lab_id, r.name, r.permissions, r.rank, r.color, r.created_at
           FROM lab.member_roles mr
           JOIN lab.roles r ON mr.role_id = r.id
          WHERE mr.lab_id = ${labId} AND mr.user_id = ${userId}

--- a/slice-guard/backend/src/db/lab/role.ts
+++ b/slice-guard/backend/src/db/lab/role.ts
@@ -7,11 +7,12 @@ export async function createRole(
     name: string,
     permissions: number,
     rank: number = 0,
+    color: string | null = null,
 ): Promise<LabRoleRow> {
     const rows: LabRoleRow[] = await db`
-        INSERT INTO lab.roles (lab_id, name, permissions, rank)
-             VALUES (${labId}, ${name}, ${permissions}, ${rank})
-        RETURNING id, lab_id, name, permissions, rank, created_at
+        INSERT INTO lab.roles (lab_id, name, permissions, rank, color)
+             VALUES (${labId}, ${name}, ${permissions}, ${rank}, ${color})
+        RETURNING id, lab_id, name, permissions, rank, color, created_at
     `;
     return rows[0];
 }
@@ -22,13 +23,24 @@ export async function updateRole(
     roleId: number,
     permissions: number,
     rank?: number,
+    name?: string,
+    color?: string | null,
 ): Promise<LabRoleRow> {
     const rows: LabRoleRow[] = await db`
         UPDATE lab.roles
            SET permissions = ${permissions},
-               rank = COALESCE(${rank}, rank)
+               rank = COALESCE(${rank}, rank),
+               name = COALESCE(${name}, name),
+               color = COALESCE(${color}, color)
          WHERE id = ${roleId} AND lab_id = ${labId}
-        RETURNING id, lab_id, name, permissions, rank, created_at
+        RETURNING id, lab_id, name, permissions, rank, color, created_at
     `;
     return rows[0];
+}
+
+export async function deleteRole(db: SQL, labId: number, roleId: number): Promise<void> {
+    await db`
+        DELETE FROM lab.roles
+         WHERE id = ${roleId} AND lab_id = ${labId}
+    `;
 }

--- a/slice-guard/backend/src/http/lab/roles.ts
+++ b/slice-guard/backend/src/http/lab/roles.ts
@@ -1,5 +1,5 @@
 import { withAuth } from '../middleware';
-import { createRole, getMemberRolePermissions, updateRole, deleteRole } from '../../db/lab';
+import { createRole, getMemberRolePermissions, updateRole, deleteRole, getLab } from '../../db/lab';
 import { LabPermission } from '@shared/db/lab';
 import { hasLabPermission } from '../../utils/permissions';
 import { WsEvent } from '@shared/payloads/ws';
@@ -35,7 +35,18 @@ export const updateRoleRoute = withAuth(async (req, userId, state, params) => {
         return new Response('Unauthorized', { status: 403 });
     }
 
-    const role = await updateRole(state.db, labId, roleId, permissions, rank, name, color ?? null);
+    const lab = await getLab(state.db, labId);
+    const isDefault = lab?.default_role_id === roleId;
+    // Prevent renaming or recoloring the lab's default role
+    const role = await updateRole(
+        state.db,
+        labId,
+        roleId,
+        permissions,
+        rank,
+        isDefault ? undefined : name,
+        isDefault ? undefined : color ?? null,
+    );
     state.broadcast({ op: WsEvent.ROLE_UPDATED, d: { role } });
     return Response.json(role);
 });

--- a/slice-guard/backend/src/http/lab/roles.ts
+++ b/slice-guard/backend/src/http/lab/roles.ts
@@ -1,5 +1,5 @@
 import { withAuth } from '../middleware';
-import { createRole, getMemberRolePermissions, updateRole } from '../../db/lab';
+import { createRole, getMemberRolePermissions, updateRole, deleteRole } from '../../db/lab';
 import { LabPermission } from '@shared/db/lab';
 import { hasLabPermission } from '../../utils/permissions';
 import { WsEvent } from '@shared/payloads/ws';
@@ -10,14 +10,14 @@ import type { RoleCreatePayload, RoleUpdatePayload } from '@shared/payloads';
  */
 export const createRoleRoute = withAuth(async (req, userId, state, params) => {
     const labId = Number(params.labId);
-    const { name, permissions, rank } = (await req.json()) as RoleCreatePayload;
+    const { name, permissions, rank, color } = (await req.json()) as RoleCreatePayload;
 
     const perms = await getMemberRolePermissions(state.db, labId, userId);
     if (!hasLabPermission(perms, LabPermission.MANAGE_ROLES)) {
         return new Response('Unauthorized', { status: 403 });
     }
 
-    const role = await createRole(state.db, labId, name, permissions, rank ?? 0);
+    const role = await createRole(state.db, labId, name, permissions, rank ?? 0, color ?? null);
     state.broadcast({ op: WsEvent.ROLE_CREATED, d: { role } });
     return Response.json(role);
 });
@@ -28,14 +28,31 @@ export const createRoleRoute = withAuth(async (req, userId, state, params) => {
 export const updateRoleRoute = withAuth(async (req, userId, state, params) => {
     const labId = Number(params.labId);
     const roleId = Number(params.roleId);
-    const { permissions, rank } = (await req.json()) as RoleUpdatePayload;
+    const { permissions, rank, name, color } = (await req.json()) as RoleUpdatePayload;
 
     const perms = await getMemberRolePermissions(state.db, labId, userId);
     if (!hasLabPermission(perms, LabPermission.MANAGE_ROLES)) {
         return new Response('Unauthorized', { status: 403 });
     }
 
-    const role = await updateRole(state.db, labId, roleId, permissions, rank);
+    const role = await updateRole(state.db, labId, roleId, permissions, rank, name, color ?? null);
     state.broadcast({ op: WsEvent.ROLE_UPDATED, d: { role } });
     return Response.json(role);
+});
+
+/**
+ * DELETE /api/labs/:labId/roles/:roleId
+ */
+export const deleteRoleRoute = withAuth(async (req, userId, state, params) => {
+    const labId = Number(params.labId);
+    const roleId = Number(params.roleId);
+
+    const perms = await getMemberRolePermissions(state.db, labId, userId);
+    if (!hasLabPermission(perms, LabPermission.MANAGE_ROLES)) {
+        return new Response('Unauthorized', { status: 403 });
+    }
+
+    await deleteRole(state.db, labId, roleId);
+    state.broadcast({ op: WsEvent.ROLE_DELETED, d: { labId, roleId } });
+    return new Response(null, { status: 204 });
 });

--- a/slice-guard/backend/src/server.ts
+++ b/slice-guard/backend/src/server.ts
@@ -56,6 +56,7 @@ export class Server {
                 },
                 '/api/labs/:labId/roles/:roleId': {
                     PATCH: (req) => withLogging(lab.updateRoleRoute)(req, this.state, req.params),
+                    DELETE: (req) => withLogging(lab.deleteRoleRoute)(req, this.state, req.params),
                 },
                 '/api/labs/:labId/members': {
                     POST: (req) => withLogging(lab.addMemberRoute)(req, this.state, req.params),

--- a/slice-guard/backend/src/utils/lab_state.ts
+++ b/slice-guard/backend/src/utils/lab_state.ts
@@ -24,7 +24,7 @@ export async function getUserLabStates(db: SQL, userId: number): Promise<LabStat
     for (const lab of labs) {
         // Load roles for the lab
         const roles: LabRole[] = (await db`
-      SELECT id, lab_id, name, permissions, rank, created_at
+      SELECT id, lab_id, name, permissions, rank, color, created_at
         FROM lab.roles WHERE lab_id = ${lab.id}
         ORDER BY rank DESC, id ASC`) as any;
 
@@ -93,7 +93,7 @@ export async function getLabState(
 
     // Load roles
     const roles: LabRole[] = (await db`
-    SELECT id, lab_id, name, permissions, rank, created_at
+    SELECT id, lab_id, name, permissions, rank, color, created_at
       FROM lab.roles WHERE lab_id = ${labId}
       ORDER BY rank DESC, id ASC`) as any;
 

--- a/slice-guard/backend/tests/lab.test.ts
+++ b/slice-guard/backend/tests/lab.test.ts
@@ -99,22 +99,22 @@ test('updateLab updates fields', async () => {
 test('createRole inserts expected values', async () => {
     const role = sampleRole();
     const db = createMockSQL([[role]]);
-    const result = await createRole(db as any, role.lab_id, role.name, role.permissions as number);
+    const result = await createRole(db as any, role.lab_id, role.name, role.permissions as number, 0, null);
     expect(normalize(db.queries.at(-1))).toBe(
-        'INSERT INTO lab.roles (lab_id, name, permissions) VALUES ($1, $2, $3) RETURNING id, lab_id, name, permissions, created_at',
+        'INSERT INTO lab.roles (lab_id, name, permissions, rank, color) VALUES ($1, $2, $3, $4, $5) RETURNING id, lab_id, name, permissions, rank, color, created_at',
     );
-    expect(db.params.at(-1)).toEqual([role.lab_id, role.name, role.permissions]);
+    expect(db.params.at(-1)).toEqual([role.lab_id, role.name, role.permissions, 0, null]);
     expect(result).toEqual(role);
 });
 
 test('updateRole updates permissions', async () => {
     const role = sampleRole();
     const db = createMockSQL([[role]]);
-    const result = await updateRole(db as any, role.lab_id, role.id, role.permissions as number);
+    const result = await updateRole(db as any, role.lab_id, role.id, role.permissions as number, undefined, undefined, null);
     expect(normalize(db.queries.at(-1))).toBe(
-        'UPDATE lab.roles SET permissions = $1 WHERE id = $2 AND lab_id = $3 RETURNING id, lab_id, name, permissions, created_at',
+        'UPDATE lab.roles SET permissions = $1, rank = COALESCE($2, rank), name = COALESCE($3, name), color = COALESCE($4, color) WHERE id = $5 AND lab_id = $6 RETURNING id, lab_id, name, permissions, rank, color, created_at',
     );
-    expect(db.params.at(-1)).toEqual([role.permissions, role.id, role.lab_id]);
+    expect(db.params.at(-1)).toEqual([role.permissions, undefined, undefined, null, role.id, role.lab_id]);
     expect(result).toEqual(role);
 });
 
@@ -148,7 +148,7 @@ test('getMemberRolePermissions selects join', async () => {
     expect(normalize(db.queries[0])).toBe('SELECT owner_id FROM lab.labs WHERE id = $1');
     expect(db.params[0]).toEqual([1]);
     expect(normalize(db.queries[1])).toBe(
-        'SELECT r.permissions FROM lab.member_roles mr JOIN lab.roles r ON mr.role_id = r.id WHERE mr.lab_id = $1 AND mr.user_id = $2',
+        'SELECT r.permissions FROM lab.member_roles mr JOIN lab.roles r ON mr.role_id = r.id WHERE mr.lab_id = $1 AND mr.user_id = $2 ORDER BY r.rank DESC, r.id ASC LIMIT 1',
     );
     expect(db.params[1]).toEqual([1, 2]);
     expect(result).toEqual(8);

--- a/slice-guard/frontend/package.json
+++ b/slice-guard/frontend/package.json
@@ -18,7 +18,9 @@
         "@tailwindcss/vite": "^4.1.11",
         "pinia": "3.0.3",
         "vue": "^3.5.13",
-        "vue-router": "^4.3.2"
+        "vue-router": "^4.3.2",
+        "@vueuse/integrations": "^13.6.0",
+        "sortablejs": "^1.15.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/slice-guard/frontend/src/components/channels/MockChannelMessage.vue
+++ b/slice-guard/frontend/src/components/channels/MockChannelMessage.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import UserAvatar from '../UserAvatar.vue';
+
+/**
+ * Mock channel message used in role color preview.
+ * Displays a user's name in the provided color and example content.
+ */
+const props = defineProps<{
+    name: string;
+    color: string;
+    content: string;
+}>();
+</script>
+
+<template>
+    <div class="hover:bg-surface-low mb-2 flex items-start gap-2 rounded-xl p-2">
+        <UserAvatar
+            :user="{ id: 0, name: props.name }"
+            size="size-8"
+        />
+        <div>
+            <div class="flex items-center gap-2">
+                <span
+                    class="text-sm font-medium"
+                    :style="{ color: props.color }"
+                    >{{ props.name }}</span
+                >
+                <span class="text-fg-tertiary text-xs">00:00</span>
+            </div>
+            <div class="text-fg-primary text-left text-sm">{{ props.content }}</div>
+        </div>
+    </div>
+</template>

--- a/slice-guard/frontend/src/modals/SettingsModal.vue
+++ b/slice-guard/frontend/src/modals/SettingsModal.vue
@@ -105,7 +105,7 @@ onUnmounted(() => {
                         </div>
                     </div>
                 </div>
-                <div class="bg-surface-low flex h-full w-full px-7 py-10">
+                <div class="bg-surface-low flex h-full w-full overflow-y-scroll px-7 py-10">
                     <div class="h-full w-[80%]">
                         <component :is="activePage.component" />
                     </div>

--- a/slice-guard/frontend/src/modals/lab_settings/LabSettings.vue
+++ b/slice-guard/frontend/src/modals/lab_settings/LabSettings.vue
@@ -1,10 +1,29 @@
 <script setup lang="ts">
 import SettingsModal from '../SettingsModal.vue';
 import { defineAsyncComponent } from 'vue';
+import { useRoute } from 'vue-router';
+import { useLabsStore } from '../../store/labs';
+import { hasLabPermission } from '../../utils/permissions';
+import { LabPermission } from '@shared/db/lab';
 defineEmits(['close']);
+
+const route = useRoute();
+const labs = useLabsStore();
+const labId = Number(route.params.id);
+const perms = labs.getLabPermissions(labId);
+
 const pages = {
     'lab settings': [
         { name: 'General', component: defineAsyncComponent(() => import('./General.vue')), id: 1 },
+        ...(hasLabPermission(perms, LabPermission.MANAGE_ROLES)
+            ? [
+                {
+                    name: 'Roles',
+                    component: defineAsyncComponent(() => import('./Roles.vue')),
+                    id: 2,
+                },
+            ]
+            : []),
     ],
 };
 </script>

--- a/slice-guard/frontend/src/modals/lab_settings/Roles.vue
+++ b/slice-guard/frontend/src/modals/lab_settings/Roles.vue
@@ -1,0 +1,194 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+import { useRoute } from 'vue-router';
+import { useLabsStore } from '../../store/labs';
+import { useAuthStore } from '../../store/auth';
+import { apiFetch } from '../../services/api';
+import Button from '../../components/Button.vue';
+import { LabPermission, type LabRole } from '@shared/db/lab';
+
+const route = useRoute();
+const labs = useLabsStore();
+const auth = useAuthStore();
+
+const labId = Number(route.params.id);
+const roles = computed(() => labs.getLabRoles(labId));
+
+const member = labs.members.get(labId)?.get(auth.user?.id ?? 0) ?? null;
+const topRank = member?.roles[0]?.rank ?? 0;
+
+const selectedId = ref<number | null>(roles.value[0]?.id ?? null);
+const selectedRole = computed(() => roles.value.find((r) => r.id === selectedId.value) || null);
+
+const roleName = ref('');
+const roleColor = ref<string>('#000000');
+const permMask = ref<number>(0);
+
+watch(selectedRole, (r) => {
+    if (r) {
+        roleName.value = r.name;
+        roleColor.value = r.color || '#000000';
+        permMask.value = Number(r.permissions);
+    }
+});
+
+function togglePerm(bit: number) {
+    permMask.value ^= bit;
+}
+
+const editable = computed(() => !!selectedRole.value && selectedRole.value.rank <= topRank);
+
+const PERMS = [
+    { bit: LabPermission.EDIT_LAB, label: 'Edit Lab', desc: 'Change basic lab info.' },
+    { bit: LabPermission.MANAGE_ROLES, label: 'Manage Roles', desc: 'Create or modify roles.' },
+    { bit: LabPermission.REMOVE_USER, label: 'Remove Users', desc: 'Kick members from the lab.' },
+    { bit: LabPermission.DELETE_LAB, label: 'Delete Lab', desc: 'Delete this lab permanently.' },
+    {
+        bit: LabPermission.CREATE_REQUEST,
+        label: 'Create Requests',
+        desc: 'Submit new print requests.',
+    },
+    {
+        bit: LabPermission.MANAGE_REQUESTS,
+        label: 'Manage Requests',
+        desc: 'Approve or deny requests.',
+    },
+    { bit: LabPermission.READ, label: 'Read Messages', desc: 'View messages and requests.' },
+    { bit: LabPermission.WRITE, label: 'Send Messages', desc: 'Send messages and requests.' },
+    {
+        bit: LabPermission.CREATE_INVITES,
+        label: 'Create Invites',
+        desc: 'Generate invites to the lab.',
+    },
+    {
+        bit: LabPermission.MANAGE_INVITES,
+        label: 'Manage Invites',
+        desc: 'Update or revoke invites.',
+    },
+];
+
+async function save() {
+    if (!selectedRole.value) {
+        return;
+    }
+    await apiFetch(`/labs/${labId}/roles/${selectedRole.value.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            name: roleName.value,
+            color: roleColor.value,
+            permissions: permMask.value,
+            rank: selectedRole.value.rank,
+        }),
+    });
+}
+
+async function createRole() {
+    const res = await apiFetch(`/labs/${labId}/roles`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            name: 'new role',
+            color: '#888888',
+            permissions: 0,
+            rank: topRank,
+        }),
+    });
+    if (res.ok) {
+        const role: LabRole = await res.json();
+        selectedId.value = role.id;
+    }
+}
+
+async function removeRole() {
+    if (!selectedRole.value) {
+        return;
+    }
+    await apiFetch(`/labs/${labId}/roles/${selectedRole.value.id}`, { method: 'DELETE' });
+    selectedId.value = roles.value[0]?.id ?? null;
+}
+</script>
+<template>
+    <div class="flex gap-4">
+        <aside class="border-surface-high w-48 border-r pr-2">
+            <ul class="flex flex-col gap-1">
+                <li
+                    v-for="r in roles"
+                    :key="r.id"
+                    class="hover:bg-surface-high cursor-pointer rounded p-2"
+                    :class="{ 'bg-surface-high': selectedId === r.id }"
+                    @click="selectedId = r.id"
+                >
+                    {{ r.name }}
+                </li>
+            </ul>
+            <Button
+                variant="secondary"
+                class="mt-2 w-full"
+                @click="createRole"
+                >New Role</Button
+            >
+        </aside>
+        <div
+            v-if="selectedRole"
+            class="flex flex-1 flex-col gap-4"
+            :class="!editable ? 'pointer-events-none opacity-50' : ''"
+        >
+            <label class="flex flex-col gap-1">
+                <span>Name</span>
+                <input
+                    v-model="roleName"
+                    class="bg-surface-high rounded p-2"
+                />
+            </label>
+            <div class="flex flex-col gap-2">
+                <label class="flex items-center gap-2">
+                    <span>Color</span>
+                    <input
+                        v-model="roleColor"
+                        type="color"
+                        class="h-8 w-16 border-none p-0"
+                    />
+                </label>
+                <div class="bg-surface-high rounded p-2">
+                    <span :style="{ color: roleColor }">{{ auth.user?.name || 'User' }}</span>
+                    : This is how a message will look.
+                </div>
+            </div>
+            <div class="flex flex-col gap-2">
+                <h3 class="font-semibold">Permissions</h3>
+                <label
+                    v-for="p in PERMS"
+                    :key="p.bit"
+                    class="flex cursor-pointer items-center gap-2"
+                >
+                    <input
+                        type="checkbox"
+                        :checked="(permMask & p.bit) !== 0"
+                        @change="togglePerm(p.bit)"
+                    />
+                    <div>
+                        <div class="font-medium">{{ p.label }}</div>
+                        <div class="text-content-dimmed text-sm">{{ p.desc }}</div>
+                    </div>
+                </label>
+            </div>
+            <div class="mt-auto flex justify-between">
+                <Button
+                    variant="danger"
+                    @click="removeRole"
+                    >Delete</Button
+                >
+                <Button
+                    variant="primary"
+                    @click="save"
+                    >Save</Button
+                >
+            </div>
+        </div>
+        <div
+            v-else
+            class="flex-1"
+        />
+    </div>
+</template>

--- a/slice-guard/frontend/src/modals/lab_settings/Roles.vue
+++ b/slice-guard/frontend/src/modals/lab_settings/Roles.vue
@@ -18,6 +18,7 @@ const labId = Number(route.params.id);
 const roles = computed(() => labs.getLabRoles(labId));
 const roleList = ref<LabRole[]>([]);
 const selectedId = ref<number | null>(null);
+const defaultRoleId = labs.getLab(labId)?.default_role_id ?? null;
 
 watch(
     roles,
@@ -39,6 +40,7 @@ const roleName = ref('');
 const roleColor = ref<string>('#000000');
 const permMask = ref<number>(0);
 
+// Keep form fields in sync with the selected role
 watch(selectedRole, (r) => {
     if (r) {
         roleName.value = r.name;
@@ -47,11 +49,16 @@ watch(selectedRole, (r) => {
     }
 });
 
+/**
+ * Toggle a permission bit on or off in the local mask.
+ */
 function togglePerm(bit: number) {
     permMask.value ^= bit;
 }
 
-const editable = computed(() => !!selectedRole.value && selectedRole.value.rank <= topRank);
+const manageable = computed(() => !!selectedRole.value && selectedRole.value.rank <= topRank);
+const isDefault = computed(() => selectedRole.value?.id === defaultRoleId);
+const editable = computed(() => manageable.value && !isDefault.value);
 
 const listEl = ref<HTMLElement | null>(null);
 
@@ -61,6 +68,7 @@ useSortable(listEl, roleList, {
     onEnd: async (evt) => {
         const firstEditable = roleList.value.findIndex((r) => r.rank <= topRank);
         if (evt.newIndex < firstEditable) {
+            // Revert if trying to move above unmanaged roles
             roleList.value = [...roleList.value].sort((a, b) => b.rank - a.rank);
             return;
         }
@@ -68,12 +76,10 @@ useSortable(listEl, roleList, {
         const updates: { id: number; rank: number; permissions: number }[] = [];
         roleList.value.forEach((r, idx) => {
             const newRank = total - idx;
-            if (r.rank !== newRank) {
-                if (r.rank <= topRank) {
-                    updates.push({ id: r.id, rank: newRank, permissions: Number(r.permissions) });
-                }
-                r.rank = newRank;
+            if (r.rank !== newRank && r.rank <= topRank) {
+                updates.push({ id: r.id, rank: newRank, permissions: Number(r.permissions) });
             }
+            r.rank = newRank;
         });
         for (const u of updates) {
             await apiFetch(`/labs/${labId}/roles/${u.id}`, {
@@ -81,6 +87,11 @@ useSortable(listEl, roleList, {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ permissions: u.permissions, rank: u.rank }),
             });
+            // Update store immediately so order persists
+            const role = labs.roles.get(labId)?.get(u.id);
+            if (role) {
+                role.rank = u.rank;
+            }
         }
     },
 });
@@ -114,6 +125,9 @@ const PERMS = [
     },
 ];
 
+/**
+ * Persist changes made to the currently selected role.
+ */
 async function save() {
     if (!selectedRole.value) {
         return;
@@ -128,9 +142,20 @@ async function save() {
             rank: selectedRole.value.rank,
         }),
     });
+    // Sync updated role back into the store
+    const role = labs.roles.get(labId)?.get(selectedRole.value.id);
+    if (role) {
+        role.name = roleName.value;
+        role.color = roleColor.value;
+        role.permissions = permMask.value;
+    }
 }
 
+/**
+ * Create a new role at a rank the current user can manage and select it.
+ */
 async function createRole() {
+    const defaultRank = roleList.value.find((r) => r.id === defaultRoleId)?.rank ?? 0;
     const res = await apiFetch(`/labs/${labId}/roles`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -138,15 +163,21 @@ async function createRole() {
             name: 'new role',
             color: '#888888',
             permissions: 0,
-            rank: topRank,
+            rank: Math.max(defaultRank + 1, topRank),
         }),
     });
     if (res.ok) {
         const role: LabRole = await res.json();
+        labs.roles.get(labId)?.set(role.id, role);
+        roleList.value.push(role);
+        roleList.value.sort((a, b) => b.rank - a.rank);
         selectedId.value = role.id;
     }
 }
 
+/**
+ * Remove the currently selected role.
+ */
 async function removeRole() {
     if (!selectedRole.value) {
         return;
@@ -156,8 +187,8 @@ async function removeRole() {
 }
 </script>
 <template>
-    <div class="flex gap-4">
-        <aside class="border-surface-high w-48 border-r pr-2">
+    <div class="flex h-full gap-4 overflow-y-auto">
+        <aside class="border-surface w-48 border-r pr-2">
             <ul
                 ref="listEl"
                 class="flex flex-col gap-1"
@@ -165,9 +196,9 @@ async function removeRole() {
                 <li
                     v-for="r in roleList"
                     :key="r.id"
-                    class="hover:bg-surface-high flex cursor-pointer items-center gap-2 rounded p-2"
+                    class="hover:bg-surface flex cursor-pointer items-center gap-2 rounded-lg p-2"
                     :class="[
-                        { 'bg-surface-high': selectedId === r.id },
+                        { 'bg-surface': selectedId === r.id },
                         r.rank <= topRank ? 'draggable' : '',
                     ]"
                     @click="selectedId = r.id"
@@ -189,13 +220,14 @@ async function removeRole() {
         <div
             v-if="selectedRole"
             class="flex flex-1 flex-col gap-4"
-            :class="!editable ? 'pointer-events-none opacity-50' : ''"
+            :class="!manageable ? 'pointer-events-none opacity-50' : ''"
         >
             <label class="flex flex-col gap-1">
                 <span>Name</span>
                 <input
                     v-model="roleName"
-                    class="bg-surface-high rounded p-2"
+                    :disabled="isDefault"
+                    class="bg-surface rounded-lg p-2 disabled:opacity-50"
                 />
             </label>
             <div class="flex flex-col gap-2">
@@ -204,10 +236,11 @@ async function removeRole() {
                     <input
                         v-model="roleColor"
                         type="color"
-                        class="h-8 w-16 border-none p-0"
+                        :disabled="isDefault"
+                        class="h-8 w-16 rounded border-none p-0 disabled:opacity-50"
                     />
                 </label>
-                <div class="bg-surface-high max-h-40 rounded p-2">
+                <div class="bg-surface max-h-40 rounded-lg p-2">
                     <MockChannelMessage
                         :name="auth.user?.name || 'User'"
                         :color="roleColor"
@@ -222,30 +255,44 @@ async function removeRole() {
             </div>
             <div class="flex flex-col gap-2">
                 <h3 class="font-semibold">Permissions</h3>
-                <label
-                    v-for="p in PERMS"
-                    :key="p.bit"
-                    class="flex cursor-pointer items-center gap-2"
-                >
-                    <input
-                        type="checkbox"
-                        :checked="(permMask & p.bit) !== 0"
-                        @change="togglePerm(p.bit)"
-                    />
-                    <div>
-                        <div class="font-medium">{{ p.label }}</div>
-                        <div class="text-content-dimmed text-sm">{{ p.desc }}</div>
+                <div class="grid gap-3 sm:grid-cols-2">
+                    <div
+                        v-for="p in PERMS"
+                        :key="p.bit"
+                        class="bg-surface flex items-center justify-between rounded-lg p-3"
+                    >
+                        <div>
+                            <div class="font-medium">{{ p.label }}</div>
+                            <div class="text-content-dimmed text-sm">{{ p.desc }}</div>
+                        </div>
+                        <label class="relative inline-flex cursor-pointer items-center">
+                            <input
+                                type="checkbox"
+                                class="peer sr-only"
+                                :checked="(permMask & p.bit) !== 0"
+                                @change="togglePerm(p.bit)"
+                            />
+                            <div
+                                class="bg-surface-low h-5 w-10 rounded-full transition-colors peer-checked:bg-accent"
+                            >
+                                <span
+                                    class="bg-surface absolute left-0.5 top-0.5 h-4 w-4 rounded-full transition-transform peer-checked:translate-x-5"
+                                />
+                            </div>
+                        </label>
                     </div>
-                </label>
+                </div>
             </div>
             <div class="mt-auto flex justify-between">
                 <Button
                     variant="danger"
+                    :disabled="isDefault"
                     @click="removeRole"
                     >Delete</Button
                 >
                 <Button
                     variant="primary"
+                    :disabled="!manageable"
                     @click="save"
                     >Save</Button
                 >

--- a/slice-guard/frontend/src/modals/lab_settings/Roles.vue
+++ b/slice-guard/frontend/src/modals/lab_settings/Roles.vue
@@ -72,26 +72,24 @@ useSortable(listEl, roleList, {
             roleList.value = [...roleList.value].sort((a, b) => b.rank - a.rank);
             return;
         }
-        const total = roleList.value.length;
+
         const updates: { id: number; rank: number; permissions: number }[] = [];
-        roleList.value.forEach((r, idx) => {
-            const newRank = total - idx;
+
+        roleList.value.forEach((r, newRank) => {
             if (r.rank !== newRank && r.rank <= topRank) {
                 updates.push({ id: r.id, rank: newRank, permissions: Number(r.permissions) });
             }
             r.rank = newRank;
         });
+
         for (const u of updates) {
+            // This will send a ROLE_UPDATE causing our cache to be up to date, no need
+            // to do it manually.
             await apiFetch(`/labs/${labId}/roles/${u.id}`, {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ permissions: u.permissions, rank: u.rank }),
             });
-            // Update store immediately so order persists
-            const role = labs.roles.get(labId)?.get(u.id);
-            if (role) {
-                role.rank = u.rank;
-            }
         }
     },
 });
@@ -273,10 +271,10 @@ async function removeRole() {
                                 @change="togglePerm(p.bit)"
                             />
                             <div
-                                class="bg-surface-low h-5 w-10 rounded-full transition-colors peer-checked:bg-accent"
+                                class="bg-surface-low peer-checked:bg-accent h-5 w-10 rounded-full transition-colors"
                             >
                                 <span
-                                    class="bg-surface absolute left-0.5 top-0.5 h-4 w-4 rounded-full transition-transform peer-checked:translate-x-5"
+                                    class="bg-surface absolute top-0.5 left-0.5 h-4 w-4 rounded-full transition-transform peer-checked:translate-x-5"
                                 />
                             </div>
                         </label>

--- a/slice-guard/frontend/src/modals/lab_settings/Roles.vue
+++ b/slice-guard/frontend/src/modals/lab_settings/Roles.vue
@@ -6,6 +6,9 @@ import { useAuthStore } from '../../store/auth';
 import { apiFetch } from '../../services/api';
 import Button from '../../components/Button.vue';
 import { LabPermission, type LabRole } from '@shared/db/lab';
+import { useSortable } from '@vueuse/integrations/useSortable';
+import MockChannelMessage from '../../components/channels/MockChannelMessage.vue';
+import { Bars3Icon } from '@heroicons/vue/24/outline';
 
 const route = useRoute();
 const labs = useLabsStore();
@@ -13,12 +16,24 @@ const auth = useAuthStore();
 
 const labId = Number(route.params.id);
 const roles = computed(() => labs.getLabRoles(labId));
+const roleList = ref<LabRole[]>([]);
+const selectedId = ref<number | null>(null);
+
+watch(
+    roles,
+    (val) => {
+        roleList.value = [...val].sort((a, b) => b.rank - a.rank);
+        if (!selectedId.value && roleList.value.length > 0) {
+            selectedId.value = roleList.value[0].id;
+        }
+    },
+    { immediate: true },
+);
 
 const member = labs.members.get(labId)?.get(auth.user?.id ?? 0) ?? null;
 const topRank = member?.roles[0]?.rank ?? 0;
 
-const selectedId = ref<number | null>(roles.value[0]?.id ?? null);
-const selectedRole = computed(() => roles.value.find((r) => r.id === selectedId.value) || null);
+const selectedRole = computed(() => roleList.value.find((r) => r.id === selectedId.value) || null);
 
 const roleName = ref('');
 const roleColor = ref<string>('#000000');
@@ -37,6 +52,38 @@ function togglePerm(bit: number) {
 }
 
 const editable = computed(() => !!selectedRole.value && selectedRole.value.rank <= topRank);
+
+const listEl = ref<HTMLElement | null>(null);
+
+useSortable(listEl, roleList, {
+    animation: 150,
+    draggable: '.draggable',
+    onEnd: async (evt) => {
+        const firstEditable = roleList.value.findIndex((r) => r.rank <= topRank);
+        if (evt.newIndex < firstEditable) {
+            roleList.value = [...roleList.value].sort((a, b) => b.rank - a.rank);
+            return;
+        }
+        const total = roleList.value.length;
+        const updates: { id: number; rank: number; permissions: number }[] = [];
+        roleList.value.forEach((r, idx) => {
+            const newRank = total - idx;
+            if (r.rank !== newRank) {
+                if (r.rank <= topRank) {
+                    updates.push({ id: r.id, rank: newRank, permissions: Number(r.permissions) });
+                }
+                r.rank = newRank;
+            }
+        });
+        for (const u of updates) {
+            await apiFetch(`/labs/${labId}/roles/${u.id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ permissions: u.permissions, rank: u.rank }),
+            });
+        }
+    },
+});
 
 const PERMS = [
     { bit: LabPermission.EDIT_LAB, label: 'Edit Lab', desc: 'Change basic lab info.' },
@@ -105,21 +152,31 @@ async function removeRole() {
         return;
     }
     await apiFetch(`/labs/${labId}/roles/${selectedRole.value.id}`, { method: 'DELETE' });
-    selectedId.value = roles.value[0]?.id ?? null;
+    selectedId.value = roleList.value[0]?.id ?? null;
 }
 </script>
 <template>
     <div class="flex gap-4">
         <aside class="border-surface-high w-48 border-r pr-2">
-            <ul class="flex flex-col gap-1">
+            <ul
+                ref="listEl"
+                class="flex flex-col gap-1"
+            >
                 <li
-                    v-for="r in roles"
+                    v-for="r in roleList"
                     :key="r.id"
-                    class="hover:bg-surface-high cursor-pointer rounded p-2"
-                    :class="{ 'bg-surface-high': selectedId === r.id }"
+                    class="hover:bg-surface-high flex cursor-pointer items-center gap-2 rounded p-2"
+                    :class="[
+                        { 'bg-surface-high': selectedId === r.id },
+                        r.rank <= topRank ? 'draggable' : '',
+                    ]"
                     @click="selectedId = r.id"
                 >
-                    {{ r.name }}
+                    <Bars3Icon
+                        v-if="r.rank <= topRank"
+                        class="text-content-dimmed h-4 w-4 flex-shrink-0 cursor-move"
+                    />
+                    <span>{{ r.name }}</span>
                 </li>
             </ul>
             <Button
@@ -150,9 +207,17 @@ async function removeRole() {
                         class="h-8 w-16 border-none p-0"
                     />
                 </label>
-                <div class="bg-surface-high rounded p-2">
-                    <span :style="{ color: roleColor }">{{ auth.user?.name || 'User' }}</span>
-                    : This is how a message will look.
+                <div class="bg-surface-high max-h-40 rounded p-2">
+                    <MockChannelMessage
+                        :name="auth.user?.name || 'User'"
+                        :color="roleColor"
+                        content="This is how a message will look."
+                    />
+                    <MockChannelMessage
+                        name="Other member"
+                        color="#888888"
+                        content="Another message for context."
+                    />
                 </div>
             </div>
             <div class="flex flex-col gap-2">

--- a/slice-guard/shared/db/lab.ts
+++ b/slice-guard/shared/db/lab.ts
@@ -17,6 +17,7 @@ export interface LabRole {
     lab_id: number;
     name: string;
     permissions: bigint | number;
+    color?: string | null;
     /**
      * Role hierarchy rank. Higher value means higher precedence.
      */

--- a/slice-guard/shared/payloads/lab.ts
+++ b/slice-guard/shared/payloads/lab.ts
@@ -23,12 +23,17 @@ export interface RoleCreatePayload {
     permissions: number;
     /** Optional role rank (default 0). */
     rank?: number;
+    color?: string | null;
 }
 
 export interface RoleUpdatePayload {
     permissions: number;
     /** Optional new rank for the role. */
     rank?: number;
+    /** Optional new name for the role. */
+    name?: string;
+    /** Optional new color for the role. */
+    color?: string | null;
 }
 
 export interface MemberAddPayload {


### PR DESCRIPTION
## Summary
- add role color support and management endpoints
- introduce roles settings tab with permission toggles and color preview

## Testing
- `bun run lint` (fails: 103 problems)
- `bun run test` (backend tests pass; frontend script missing)


------
https://chatgpt.com/codex/tasks/task_e_68963abf8a408320b531b282ac8a0b35