### PR TITLE
feat: allow assigning lab roles

### DIFF
--- a/slice-guard/backend/WS_ROUTES.md
+++ b/slice-guard/backend/WS_ROUTES.md
@@ -29,6 +29,7 @@ in real time.
 |      17 | `LAB_CREATED`     | Server → Client | `{ lab }` full lab state when a lab is created                                                       |
 |      18 | `LAB_UPDATED`     | Server → Client | `{ lab }` broadcast when lab details change                                                          |
 |      19 | `LAB_DELETED`     | Server → Client | `{ labId }` broadcast when a lab is deleted                                                          |
+|      26 | `MEMBER_UPDATED`  | Server → Client | `{ labId, member, user }` broadcast when a member's roles change                                     |
 
 Payload interfaces are defined in `slice-guard/shared/payloads/ws.ts` and reused
 by both the frontend and backend.

--- a/slice-guard/backend/src/db/lab/member.ts
+++ b/slice-guard/backend/src/db/lab/member.ts
@@ -86,3 +86,34 @@ export async function getMemberRoles(
     `;
     return rows;
 }
+
+/**
+ * Replace all role assignments for a member within a lab.
+ *
+ * Ensures the lab's default role is always included even if omitted
+ * from the provided list.
+ */
+export async function setMemberRoles(
+    db: SQL,
+    labId: number,
+    userId: number,
+    roleIds: number[],
+): Promise<void> {
+    const [{ default_role_id }] = await db`
+        SELECT default_role_id FROM lab.labs WHERE id = ${labId}
+    `;
+    const ids = roleIds.includes(Number(default_role_id))
+        ? roleIds
+        : [...roleIds, Number(default_role_id)];
+
+    await db`
+        DELETE FROM lab.member_roles
+         WHERE lab_id = ${labId} AND user_id = ${userId}
+    `;
+    for (const roleId of ids) {
+        await db`
+            INSERT INTO lab.member_roles (lab_id, user_id, role_id)
+                 VALUES (${labId}, ${userId}, ${roleId})
+        `;
+    }
+}

--- a/slice-guard/backend/src/http/lab/members.ts
+++ b/slice-guard/backend/src/http/lab/members.ts
@@ -6,11 +6,12 @@ import {
     listMembers,
     getMemberRoles,
     getMemberRolePermissions,
+    setMemberRoles,
 } from '../../db/lab';
 import { findPublicUserById } from '../../db/user';
 import { LabPermission, type LabMember } from '@shared/db/lab';
 import { hasLabPermission } from '../../utils/permissions';
-import type { MemberAddPayload } from '@shared/payloads';
+import type { MemberAddPayload, MemberRoleUpdatePayload } from '@shared/payloads';
 import { WsEvent } from '@shared/payloads/ws';
 
 /**
@@ -127,4 +128,29 @@ export const listMembersRoute = withAuth(async (_req, userId, state, params) => 
     }
 
     return Response.json(results);
+});
+
+/**
+ * PUT /api/labs/:labId/members/:userId/roles
+ */
+export const updateMemberRolesRoute = withAuth(async (req, userId, state, params) => {
+    const labId = Number(params.labId);
+    const targetId = Number(params.userId);
+    const { roleIds } = (await req.json()) as MemberRoleUpdatePayload;
+
+    const perms = await getMemberRolePermissions(state.db, labId, userId);
+    if (!hasLabPermission(perms, LabPermission.MANAGE_ROLES)) {
+        return new Response('Unauthorized', { status: 403 });
+    }
+
+    await setMemberRoles(state.db, labId, targetId, roleIds);
+    const memberRow = await getMember(state.db, labId, targetId);
+    if (!memberRow) {
+        return new Response('Not found', { status: 404 });
+    }
+    const roles = await getMemberRoles(state.db, labId, targetId);
+    const member: LabMember = { ...memberRow, roles };
+    const user = await findPublicUserById(state.db, targetId);
+    state.broadcast({ op: WsEvent.MEMBER_UPDATED, d: { labId, member, user } });
+    return Response.json(member);
 });

--- a/slice-guard/backend/src/server.ts
+++ b/slice-guard/backend/src/server.ts
@@ -67,6 +67,10 @@ export class Server {
                         withLogging(lab.removeMemberRoute)(req, this.state, req.params),
                     GET: (req) => withLogging(lab.getMemberRoute)(req, this.state, req.params),
                 },
+                '/api/labs/:labId/members/:userId/roles': {
+                    PUT: (req) =>
+                        withLogging(lab.updateMemberRolesRoute)(req, this.state, req.params),
+                },
                 '/api/labs/:labId/members/@me': {
                     DELETE: (req) => withLogging(lab.leaveLabRoute)(req, this.state, req.params),
                 },

--- a/slice-guard/backend/tests/lab.test.ts
+++ b/slice-guard/backend/tests/lab.test.ts
@@ -9,6 +9,7 @@ import {
     removeMember,
     listMembers,
     getMemberRolePermissions,
+    setMemberRoles,
     type LabRow,
     type LabRoleRow,
     type LabMemberRow,
@@ -99,7 +100,14 @@ test('updateLab updates fields', async () => {
 test('createRole inserts expected values', async () => {
     const role = sampleRole();
     const db = createMockSQL([[role]]);
-    const result = await createRole(db as any, role.lab_id, role.name, role.permissions as number, 0, null);
+    const result = await createRole(
+        db as any,
+        role.lab_id,
+        role.name,
+        role.permissions as number,
+        0,
+        null,
+    );
     expect(normalize(db.queries.at(-1))).toBe(
         'INSERT INTO lab.roles (lab_id, name, permissions, rank, color) VALUES ($1, $2, $3, $4, $5) RETURNING id, lab_id, name, permissions, rank, color, created_at',
     );
@@ -110,11 +118,26 @@ test('createRole inserts expected values', async () => {
 test('updateRole updates permissions', async () => {
     const role = sampleRole();
     const db = createMockSQL([[role]]);
-    const result = await updateRole(db as any, role.lab_id, role.id, role.permissions as number, undefined, undefined, null);
+    const result = await updateRole(
+        db as any,
+        role.lab_id,
+        role.id,
+        role.permissions as number,
+        undefined,
+        undefined,
+        null,
+    );
     expect(normalize(db.queries.at(-1))).toBe(
         'UPDATE lab.roles SET permissions = $1, rank = COALESCE($2, rank), name = COALESCE($3, name), color = COALESCE($4, color) WHERE id = $5 AND lab_id = $6 RETURNING id, lab_id, name, permissions, rank, color, created_at',
     );
-    expect(db.params.at(-1)).toEqual([role.permissions, undefined, undefined, null, role.id, role.lab_id]);
+    expect(db.params.at(-1)).toEqual([
+        role.permissions,
+        undefined,
+        undefined,
+        null,
+        role.id,
+        role.lab_id,
+    ]);
     expect(result).toEqual(role);
 });
 
@@ -163,4 +186,23 @@ test('listMembers selects expected', async () => {
     );
     expect(db.params.at(-1)).toEqual([m.lab_id]);
     expect(result).toEqual([m]);
+});
+
+test('setMemberRoles replaces roles and enforces default', async () => {
+    const db = createMockSQL([[{ default_role_id: 5 }]]);
+    await setMemberRoles(db as any, 1, 2, [3]);
+    expect(normalize(db.queries[0])).toBe('SELECT default_role_id FROM lab.labs WHERE id = $1');
+    expect(db.params[0]).toEqual([1]);
+    expect(normalize(db.queries[1])).toBe(
+        'DELETE FROM lab.member_roles WHERE lab_id = $1 AND user_id = $2',
+    );
+    expect(db.params[1]).toEqual([1, 2]);
+    expect(normalize(db.queries[2])).toBe(
+        'INSERT INTO lab.member_roles (lab_id, user_id, role_id) VALUES ($1, $2, $3)',
+    );
+    expect(db.params[2]).toEqual([1, 2, 3]);
+    expect(normalize(db.queries[3])).toBe(
+        'INSERT INTO lab.member_roles (lab_id, user_id, role_id) VALUES ($1, $2, $3)',
+    );
+    expect(db.params[3]).toEqual([1, 2, 5]);
 });

--- a/slice-guard/frontend/src/main.ts
+++ b/slice-guard/frontend/src/main.ts
@@ -23,6 +23,7 @@ ws.addListener(WsEvent.TAG_UPDATED, ({ tag }) => labs.updateTag(tag.lab_id, tag)
 ws.addListener(WsEvent.TAG_DELETED, ({ labId, tagId }) => labs.removeTag(labId, tagId));
 ws.addListener(WsEvent.MEMBER_JOINED, (d) => labs.addMember(d.labId, d));
 ws.addListener(WsEvent.MEMBER_LEFT, (d) => labs.handleMemberLeft(d.labId, d.userId));
+ws.addListener(WsEvent.MEMBER_UPDATED, (d) => labs.updateMember(d.labId, d));
 ws.addListener(WsEvent.LAB_UPDATED, (d) => labs.updateLab(d.lab));
 ws.addListener(WsEvent.INVITE_CREATED, (d) => labs.addInvite(d.invite.lab_id, d.invite));
 ws.addListener(WsEvent.INVITE_UPDATED, (d) => labs.updateInvite(d.invite.lab_id, d.invite));

--- a/slice-guard/frontend/src/modals/lab_settings/Roles.vue
+++ b/slice-guard/frontend/src/modals/lab_settings/Roles.vue
@@ -58,7 +58,6 @@ function togglePerm(bit: number) {
 
 const manageable = computed(() => !!selectedRole.value && selectedRole.value.rank <= topRank);
 const isDefault = computed(() => selectedRole.value?.id === defaultRoleId);
-const editable = computed(() => manageable.value && !isDefault.value);
 
 const listEl = ref<HTMLElement | null>(null);
 

--- a/slice-guard/frontend/src/store/labs.ts
+++ b/slice-guard/frontend/src/store/labs.ts
@@ -395,6 +395,20 @@ export const useLabsStore = defineStore('labs', {
                 members.set(event.member.user_id, event.member);
             }
         },
+        /** Update an existing member's data. */
+        updateMember(labId: LabId, event: MemberEvent) {
+            if (DEV) {
+                console.debug('[labs] updateMember', labId, event);
+            }
+
+            if (event.user) {
+                this.users.set(event.user.id, event.user);
+            }
+            const members = this.members.get(labId);
+            if (members && members.has(event.member.user_id)) {
+                members.set(event.member.user_id, event.member);
+            }
+        },
         /** Remove member by user id. */
         removeMember(labId: LabId, userId: UserId) {
             if (DEV) {

--- a/slice-guard/frontend/src/views/lab/dashboard/LabDashboard.vue
+++ b/slice-guard/frontend/src/views/lab/dashboard/LabDashboard.vue
@@ -117,6 +117,18 @@ watch(
     { immediate: true },
 );
 
+const memberRoleSelections = ref<Record<number, number[]>>({});
+
+watch(
+    members,
+    (ms) => {
+        for (const m of ms) {
+            memberRoleSelections.value[m.member.user_id] = m.member.roles.map((r) => r.id);
+        }
+    },
+    { immediate: true },
+);
+
 /**
  * Persist permission changes for a given role.
  */
@@ -133,6 +145,21 @@ async function updateRolePermissions(role: LabRole) {
     const updated = await res.json();
 
     labStore.updateRole(lab.value.id, updated);
+}
+
+async function updateMemberRoles(userId: number) {
+    if (!lab.value) {
+        return;
+    }
+    await apiFetch(`/labs/${lab.value.id}/members/${userId}/roles`, {
+        method: 'PUT',
+        body: JSON.stringify({
+            labId: lab.value.id,
+            userId,
+            roleIds: memberRoleSelections.value[userId],
+        }),
+        headers: { 'Content-Type': 'application/json' },
+    });
 }
 
 /**
@@ -278,6 +305,7 @@ async function createTag() {
                 <thead class="text-fg-secondary">
                     <tr>
                         <th class="text-left">Member</th>
+                        <th class="text-left">Roles</th>
                         <th class="text-left">Permissions</th>
                     </tr>
                 </thead>
@@ -288,6 +316,29 @@ async function createTag() {
                         class="text-fg-primary"
                     >
                         <td>{{ m.user?.name || m.user?.email || m.member.user_id }}</td>
+                        <td>
+                            <div class="flex items-center gap-2">
+                                <select
+                                    v-model="memberRoleSelections[m.member.user_id]"
+                                    multiple
+                                    class="border-surface-high bg-surface-low rounded text-sm"
+                                >
+                                    <option
+                                        v-for="r in roles"
+                                        :key="r.id"
+                                        :value="r.id"
+                                    >
+                                        {{ r.name }}
+                                    </option>
+                                </select>
+                                <Button
+                                    variant="secondary"
+                                    @click="updateMemberRoles(m.member.user_id)"
+                                >
+                                    Save
+                                </Button>
+                            </div>
+                        </td>
                         <td>{{ computeMemberPermissions(m.member) }}</td>
                     </tr>
                 </tbody>

--- a/slice-guard/shared/payloads/lab.ts
+++ b/slice-guard/shared/payloads/lab.ts
@@ -46,3 +46,10 @@ export interface MemberRemovePayload {
     labId: number;
     userId: number;
 }
+
+/** Payload for updating a member's role assignments. */
+export interface MemberRoleUpdatePayload {
+    labId: number;
+    userId: number;
+    roleIds: number[];
+}

--- a/slice-guard/shared/payloads/ws.ts
+++ b/slice-guard/shared/payloads/ws.ts
@@ -63,6 +63,8 @@ export enum WsEvent {
     MESSAGE_UPDATED = 24,
     /** Emitted when a message is deleted. */
     MESSAGE_DELETED = 25,
+    /** Emitted when a member's roles change. */
+    MEMBER_UPDATED = 26,
 }
 
 export type WsEventType = keyof typeof WsEvent;
@@ -201,6 +203,7 @@ export type WsPayloads = {
     [WsEvent.MESSAGE_CREATED]: { op: WsEvent.MESSAGE_CREATED; d: MessageEvent };
     [WsEvent.MESSAGE_UPDATED]: { op: WsEvent.MESSAGE_UPDATED; d: MessageEvent };
     [WsEvent.MESSAGE_DELETED]: { op: WsEvent.MESSAGE_DELETED; d: MessageDeletedEvent };
+    [WsEvent.MEMBER_UPDATED]: { op: WsEvent.MEMBER_UPDATED; d: MemberEvent };
     [WsEvent.ERROR]: { op: WsEvent.ERROR; d: ErrorPayload };
 };
 


### PR DESCRIPTION
## Summary
- allow members' roles to be updated via new `/members/:userId/roles` endpoint
- broadcast `MEMBER_UPDATED` events and handle them on the client
- add dashboard UI to select and save roles for each lab member

## Testing
- `bun run lint` *(fails: 104 problems (41 errors, 63 warnings))*
- `bun run format:check` *(fails: Code style issues found in 4 files)*
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68964ebaf23c8320b11e83d4e030878b