### PR TITLE
Refactor lab permissions and user UI

### DIFF
--- a/slice-guard/backend/src/db/lab/permissions.ts
+++ b/slice-guard/backend/src/db/lab/permissions.ts
@@ -23,12 +23,16 @@ export async function getMemberRolePermissions(
           JOIN lab.roles r ON mr.role_id = r.id
          WHERE mr.lab_id = ${labId} AND mr.user_id = ${userId}
          ORDER BY r.rank DESC, r.id ASC
-         LIMIT 1
     `;
     if (rows.length === 0) {
         return null;
     }
 
-    // Role-by-role precedence: only the highest-ranked role applies
-    return Number(rows[0].permissions);
+    // Aggregate permissions from all assigned roles while keeping the
+    // highest-ranked role as the baseline.
+    let mask = Number(rows[0].permissions);
+    for (let i = 1; i < rows.length; i += 1) {
+        mask |= Number(rows[i].permissions);
+    }
+    return mask;
 }

--- a/slice-guard/backend/src/http/lab/lab.ts
+++ b/slice-guard/backend/src/http/lab/lab.ts
@@ -34,7 +34,7 @@ export const create = withAuth(async (req, userId, state) => {
     const lab = await createLab(state.db, userId, name, description ?? null, iconUrl ?? null);
     const labState = await getLabState(state.db, lab.id, userId);
     if (labState) {
-        state.broadcast({ op: WsEvent.LAB_CREATED, d: { lab: labState } });
+        state.sendToUser(userId, { op: WsEvent.LAB_CREATED, d: { lab: labState } });
     }
     return Response.json(lab);
 });

--- a/slice-guard/backend/src/server.ts
+++ b/slice-guard/backend/src/server.ts
@@ -233,14 +233,14 @@ export class Server {
     }
 
     private async handleWebSocketOpen(ws: ServerWebSocket) {
-        this.state.sockets.add(ws);
+        this.state.addSocket(ws);
         const labs = await getUserLabStates(this.state.db, ws.data.userId);
         ws.send(JSON.stringify({ op: WsEvent.HELLO, d: { labs } }));
         logger.debug({ userId: ws.data.userId }, 'WebSocket connected');
     }
 
     private handleWebSocketClose(ws: ServerWebSocket) {
-        this.state.sockets.delete(ws);
+        this.state.removeSocket(ws);
         logger.debug({ userId: ws.data.userId }, 'WebSocket disconnected');
     }
 }

--- a/slice-guard/backend/src/utils/state.ts
+++ b/slice-guard/backend/src/utils/state.ts
@@ -15,10 +15,36 @@ export default class State {
     logger: Logger;
     // Active websocket connections
     sockets: Set<ServerWebSocket> = new Set();
+    // Active sockets keyed by user id for targeted broadcasts
+    private socketsByUser: Map<number, Set<ServerWebSocket>> = new Map();
 
     constructor(db: SQL, logger: Logger) {
         this.db = db;
         this.logger = logger;
+    }
+
+    /** Register an incoming websocket connection. */
+    addSocket(ws: ServerWebSocket) {
+        this.sockets.add(ws);
+        const collection = this.socketsByUser.get(ws.data.userId);
+        if (collection) {
+            collection.add(ws);
+        } else {
+            this.socketsByUser.set(ws.data.userId, new Set([ws]));
+        }
+    }
+
+    /** Remove a websocket from the active collections. */
+    removeSocket(ws: ServerWebSocket) {
+        this.sockets.delete(ws);
+        const collection = this.socketsByUser.get(ws.data.userId);
+        if (!collection) {
+            return;
+        }
+        collection.delete(ws);
+        if (collection.size === 0) {
+            this.socketsByUser.delete(ws.data.userId);
+        }
     }
 
     /** Broadcast a message to all connected clients. */
@@ -29,6 +55,38 @@ export default class State {
                 ws.send(raw);
             } catch (err) {
                 this.logger.error({ err }, 'Failed to send WS message');
+            }
+        }
+    }
+
+    /** Send a websocket message to a single user if they are connected. */
+    sendToUser(userId: number, msg: WsPayloadUnion) {
+        this.sendToUsers([userId], msg);
+    }
+
+    /**
+     * Send a websocket message to a set of users. Each socket is only sent the
+     * payload once even if multiple user ids map to the same underlying
+     * connection.
+     */
+    sendToUsers(userIds: Iterable<number>, msg: WsPayloadUnion) {
+        const raw = JSON.stringify(msg);
+        const delivered = new Set<ServerWebSocket>();
+        for (const userId of userIds) {
+            const sockets = this.socketsByUser.get(userId);
+            if (!sockets) {
+                continue;
+            }
+            for (const ws of sockets) {
+                if (delivered.has(ws)) {
+                    continue;
+                }
+                try {
+                    ws.send(raw);
+                    delivered.add(ws);
+                } catch (err) {
+                    this.logger.error({ err, userId }, 'Failed to send targeted WS message');
+                }
             }
         }
     }

--- a/slice-guard/backend/tests/lab.test.ts
+++ b/slice-guard/backend/tests/lab.test.ts
@@ -99,9 +99,15 @@ test('updateLab updates fields', async () => {
 test(' inserts expected values', async () => {
     const role = sampleRole();
     const db = createMockSQL([[role]]);
-    const result = await createRole(db as any, role.lab_id, role.name, role.permissions as number, null);
+    const result = await createRole(
+        db as any,
+        role.lab_id,
+        role.name,
+        role.permissions as number,
+        null,
+    );
     expect(normalize(db.queries.at(0))).toBe(
-        "INSERT INTO lab.roles (lab_id, name, permissions, rank, color) VALUES ($1, $2, $3, $4, $5) RETURNING id, lab_id, name, permissions, rank, color, created_at",
+        'INSERT INTO lab.roles (lab_id, name, permissions, rank, color) VALUES ($1, $2, $3, $4, $5) RETURNING id, lab_id, name, permissions, rank, color, created_at',
     );
     expect(db.params.at(0)).toEqual([role.lab_id, role.name, role.permissions, null, null]);
     expect(result).toEqual(role);
@@ -163,10 +169,16 @@ test('getMemberRolePermissions selects join', async () => {
     expect(normalize(db.queries[0])).toBe('SELECT owner_id FROM lab.labs WHERE id = $1');
     expect(db.params[0]).toEqual([1]);
     expect(normalize(db.queries[1])).toBe(
-        'SELECT r.permissions FROM lab.member_roles mr JOIN lab.roles r ON mr.role_id = r.id WHERE mr.lab_id = $1 AND mr.user_id = $2 ORDER BY r.rank DESC, r.id ASC LIMIT 1',
+        'SELECT r.permissions FROM lab.member_roles mr JOIN lab.roles r ON mr.role_id = r.id WHERE mr.lab_id = $1 AND mr.user_id = $2 ORDER BY r.rank DESC, r.id ASC',
     );
     expect(db.params[1]).toEqual([1, 2]);
     expect(result).toEqual(8);
+});
+
+test('getMemberRolePermissions aggregates multiple roles', async () => {
+    const db = createMockSQL([[{ owner_id: 5 }], [{ permissions: 4 }, { permissions: 2 }]]);
+    const result = await getMemberRolePermissions(db as any, 7, 9);
+    expect(result).toEqual(6);
 });
 
 test('listMembers selects expected', async () => {

--- a/slice-guard/docs/2024-05-permissions-and-ui.md
+++ b/slice-guard/docs/2024-05-permissions-and-ui.md
@@ -1,0 +1,22 @@
+# Permissions and UI Refactor Notes
+
+## Backend
+
+- Reworked `getMemberRolePermissions` to aggregate permissions from every role a member holds while still granting full access to lab owners. This fixes scenarios where secondary roles granted elevated permissions that were previously ignored.
+- Added targeted WebSocket helpers to `State` so events can be delivered to specific users. Lab creation responses now use this path to avoid leaking newly created labs to every connected client.
+
+## Frontend
+
+- Lab permissions are recomputed directly from the active member record and refreshed whenever membership or roles change. This keeps permission-gated UI accurate after role edits.
+- The lab member list now collapses on small screens and opens a detailed profile modal when a user is selected.
+- Implemented a global user profile modal showing avatars, primary details, roles, and join dates with keyboard/overlay dismissal.
+- Role management gained rank persistence through drag-and-drop, automatic rank recalculation, and real-time permission updates after edits or deletions.
+- The color picker supports Hex, RGB, and HSL inputs with live synchronization and preview feedback.
+
+## Components
+
+- Added `UserProfileModal` for richer member inspection from both the sidebar and chat messages.
+- Improved `ChannelMessage` to expose member profiles via avatar/name clicks while respecting context where a profile should not open.
+- Updated `ColorPickerModal` to provide multi-format input controls alongside the existing color wheel preview.
+
+These changes ensure lab ownership is respected, permissions remain consistent across the stack, and member management workflows are responsive on modern devices.

--- a/slice-guard/frontend/src/App.vue
+++ b/slice-guard/frontend/src/App.vue
@@ -2,6 +2,7 @@
 import { useRoute } from 'vue-router';
 import { computed } from 'vue';
 import LabBar from './components/LabBar.vue';
+import UserProfileModal from './modals/UserProfileModal.vue';
 const route = useRoute();
 const hideBar = computed(() => ['Login', 'Register'].includes(route.name as string));
 </script>
@@ -19,6 +20,7 @@ const hideBar = computed(() => ['Login', 'Register'].includes(route.name as stri
             <router-view />
         </div>
     </div>
+    <UserProfileModal />
 </template>
 
 <style scoped></style>

--- a/slice-guard/frontend/src/components/ColorWheel.vue
+++ b/slice-guard/frontend/src/components/ColorWheel.vue
@@ -12,11 +12,10 @@ import { clamp, hexToRgb, rgbToHex, rgbToHsv, hsvToRgb, normalizeHex } from '../
  * `change` event when the user finishes an interaction (pointer up).
  */
 
-interface Emits {
-    (e: 'update:modelValue', v: string): void;
-    (e: 'change', v: string): void; // fired on pointer up / finalize interaction
-}
-const emit = defineEmits<Emits>();
+const emit = defineEmits<{
+    'update:modelValue': [value: string];
+    change: [value: string];
+}>();
 
 const props = withDefaults(
     defineProps<{
@@ -67,7 +66,7 @@ let draggingSquare = false;
  * Update saturation and value based on pointer event coordinates within the
  * square selector.
  */
-function setSVFromEvent(ev: PointerEvent): void {
+function setSVFromEvent(ev: globalThis.PointerEvent): void {
     const el = squareRef.value;
     if (!el) {
         return;
@@ -80,14 +79,14 @@ function setSVFromEvent(ev: PointerEvent): void {
 }
 
 /** Begin dragging within the SV square. */
-function onSquareDown(ev: PointerEvent): void {
+function onSquareDown(ev: globalThis.PointerEvent): void {
     draggingSquare = true;
     (ev.currentTarget as HTMLElement).setPointerCapture?.(ev.pointerId);
     setSVFromEvent(ev);
 }
 
 /** Track pointer movement while dragging within SV square. */
-function onSquareMove(ev: PointerEvent): void {
+function onSquareMove(ev: globalThis.PointerEvent): void {
     if (!draggingSquare) {
         return;
     }
@@ -118,7 +117,7 @@ const squareBg = computed(() => `hsl(${Math.round(hsv.value.h)} 100% 50%)`);
 const sliderRef = ref<HTMLElement | null>(null);
 let draggingHue = false;
 /** Update hue value based on pointer position on the hue slider. */
-function setHueFromEvent(ev: PointerEvent): void {
+function setHueFromEvent(ev: globalThis.PointerEvent): void {
     const el = sliderRef.value;
     if (!el) {
         return;
@@ -129,14 +128,14 @@ function setHueFromEvent(ev: PointerEvent): void {
 }
 
 /** Start dragging on the hue slider. */
-function onHueDown(ev: PointerEvent): void {
+function onHueDown(ev: globalThis.PointerEvent): void {
     draggingHue = true;
     (ev.currentTarget as HTMLElement).setPointerCapture?.(ev.pointerId);
     setHueFromEvent(ev);
 }
 
 /** Track pointer movement while adjusting hue. */
-function onHueMove(ev: PointerEvent): void {
+function onHueMove(ev: globalThis.PointerEvent): void {
     if (!draggingHue) {
         return;
     }

--- a/slice-guard/frontend/src/components/Dropdown.vue
+++ b/slice-guard/frontend/src/components/Dropdown.vue
@@ -22,17 +22,14 @@ interface Props {
     multiple?: boolean;
 }
 
-interface Emits {
-    /** Update the selected value(s). */
-    (e: 'update:modelValue', value: number | string | null | (number | string)[]): void;
-}
-
 const props = withDefaults(defineProps<Props>(), {
     placeholder: 'Select option',
     multiple: false,
 });
 
-const emit = defineEmits<Emits>();
+const emit = defineEmits<{
+    'update:modelValue': [value: number | string | null | (number | string)[]];
+}>();
 
 const isOpen = ref(false);
 const dropdownRef = ref<HTMLElement>();

--- a/slice-guard/frontend/src/components/channels/ChannelMessage.vue
+++ b/slice-guard/frontend/src/components/channels/ChannelMessage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { computedAsync } from '@vueuse/core';
 
 import type { Message } from '@shared/db/message';
@@ -6,6 +7,7 @@ import type { User } from '@shared/db/user';
 
 import { apiFetch } from '../../services/api';
 import { useLabsStore } from '../../store/labs';
+import { useUiStore } from '../../store/ui';
 import UserAvatar from '../UserAvatar.vue';
 
 /** Props for {@link ChannelMessage}. */
@@ -14,10 +16,13 @@ export interface ChannelMessageProps {
     message: Message;
     /** Optional author; fetched if not provided. */
     author: User | null;
+    /** Lab context for opening a profile modal. */
+    labId?: number | null;
 }
 
 const props = defineProps<ChannelMessageProps>();
 const labStore = useLabsStore();
+const ui = useUiStore();
 
 /**
  * Resolve the message author, fetching the user if necessary.
@@ -40,7 +45,16 @@ async function resolveAuthor(): Promise<User | null> {
     return fetched;
 }
 
-const author = computedAsync<User | null>(resolveAuthor, null);
+const resolvedAuthor = computedAsync<User | null>(resolveAuthor, null);
+
+const canOpenProfile = computed(() => props.labId !== null && props.labId !== undefined);
+
+function openProfile(): void {
+    if (props.labId === null || props.labId === undefined) {
+        return;
+    }
+    ui.openUserProfile({ labId: props.labId, userId: props.message.user_id });
+}
 </script>
 
 <template>
@@ -49,20 +63,41 @@ const author = computedAsync<User | null>(resolveAuthor, null);
     >
         <div class="flex flex-row items-start justify-center gap-2">
             <!-- The user's avatar off to the left -->
-            <UserAvatar
-                v-if="author"
-                :user="author"
-                size="size-8"
-            />
+            <button
+                type="button"
+                class="focus-visible:outline-accent/80 rounded-full focus-visible:outline focus-visible:outline-2 disabled:cursor-default"
+                :class="canOpenProfile ? 'cursor-pointer' : 'cursor-default'"
+                :disabled="!canOpenProfile"
+                @click="openProfile"
+            >
+                <UserAvatar
+                    v-if="resolvedAuthor"
+                    :user="resolvedAuthor"
+                    size="size-8"
+                />
+                <div
+                    v-else
+                    class="h-8 w-8 rounded-full bg-gray-600"
+                />
+            </button>
 
-            <div>
+            <div class="min-w-0 flex-1">
                 <!-- Their name and when the message was created off to the right next to each other -->
                 <div class="flex flex-row items-center justify-start gap-2">
+                    <button
+                        v-if="resolvedAuthor"
+                        type="button"
+                        class="text-fg-primary focus-visible:outline-accent/70 text-left text-sm font-medium hover:underline focus-visible:outline focus-visible:outline-2 disabled:cursor-default disabled:opacity-70"
+                        :disabled="!canOpenProfile"
+                        @click="openProfile"
+                    >
+                        {{ resolvedAuthor.name || 'User ' + resolvedAuthor.id }}
+                    </button>
                     <div
-                        v-if="author"
+                        v-else
                         class="text-fg-primary text-left text-sm"
                     >
-                        {{ author.name || 'User ' + author.id }}
+                        User {{ message.user_id }}
                     </div>
                     <!-- Show the date and the time it was created-->
                     <div class="text-fg-tertiary text-left text-xs">

--- a/slice-guard/frontend/src/components/channels/ChannelMessage.vue
+++ b/slice-guard/frontend/src/components/channels/ChannelMessage.vue
@@ -65,7 +65,7 @@ function openProfile(): void {
             <!-- The user's avatar off to the left -->
             <button
                 type="button"
-                class="focus-visible:outline-accent/80 rounded-full focus-visible:outline focus-visible:outline-2 disabled:cursor-default"
+                class="focus-visible:outline-accent/80 rounded-full focus-visible:outline-2 disabled:cursor-default"
                 :class="canOpenProfile ? 'cursor-pointer' : 'cursor-default'"
                 :disabled="!canOpenProfile"
                 @click="openProfile"
@@ -87,7 +87,7 @@ function openProfile(): void {
                     <button
                         v-if="resolvedAuthor"
                         type="button"
-                        class="text-fg-primary focus-visible:outline-accent/70 text-left text-sm font-medium hover:underline focus-visible:outline focus-visible:outline-2 disabled:cursor-default disabled:opacity-70"
+                        class="text-fg-primary focus-visible:outline-accent/70 text-left text-sm font-medium hover:underline focus-visible:outline-2 disabled:cursor-default disabled:opacity-70"
                         :disabled="!canOpenProfile"
                         @click="openProfile"
                     >

--- a/slice-guard/frontend/src/modals/ColorPickerModal.vue
+++ b/slice-guard/frontend/src/modals/ColorPickerModal.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue';
+import { watchDebounced } from '@vueuse/core';
 import ColorWheel from '../components/ColorWheel.vue';
+import { clamp, normalizeHex, hexToRgb, rgbToHex, rgbToHsl, hslToRgb } from '../utils/color';
 
 /** Props for {@link ColorPickerModal}. */
 const props = withDefaults(
@@ -17,21 +19,125 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-    (e: 'update:modelValue', v: string | null): void;
-    (e: 'close'): void;
+    'update:modelValue': [value: string | null];
+    close: [];
 }>();
 
-const color = ref<string>(props.modelValue ?? '#000000');
+const color = ref<string>(normalizeHex(props.modelValue ?? '#000000'));
+const hexInput = ref<string>(color.value);
+const rgbInput = ref<string>('');
+const hslInput = ref<string>('');
+
+function syncInputs(value: string): void {
+    const normalized = normalizeHex(value);
+    if (hexInput.value !== normalized) {
+        hexInput.value = normalized;
+    }
+    const { r, g, b } = hexToRgb(normalized);
+    const rgbString = `${r}, ${g}, ${b}`;
+    if (rgbInput.value !== rgbString) {
+        rgbInput.value = rgbString;
+    }
+    const { h, s, l } = rgbToHsl(r, g, b);
+    const hslString = `${Math.round(h)}, ${Math.round(s)}, ${Math.round(l)}`;
+    if (hslInput.value !== hslString) {
+        hslInput.value = hslString;
+    }
+}
+
+syncInputs(color.value);
 
 // keep internal color in sync with bound value
 watch(
     () => props.modelValue,
     (v) => {
-        if (typeof v === 'string' && v !== color.value) {
-            color.value = v;
+        if (typeof v === 'string') {
+            const normalized = normalizeHex(v);
+            if (normalized !== color.value) {
+                color.value = normalized;
+            }
         }
     },
 );
+
+watch(color, (value) => {
+    syncInputs(value);
+});
+
+watchDebounced(
+    hexInput,
+    (value) => {
+        if (!value) {
+            return;
+        }
+        const normalized = normalizeHex(value);
+        if (normalized !== color.value) {
+            color.value = normalized;
+        }
+    },
+    { debounce: 150, maxWait: 400 },
+);
+
+watchDebounced(
+    rgbInput,
+    (value) => {
+        const tuple = parseRgb(value);
+        if (!tuple) {
+            return;
+        }
+        const next = rgbToHex(tuple[0], tuple[1], tuple[2]);
+        if (next !== color.value) {
+            color.value = next;
+        }
+    },
+    { debounce: 180, maxWait: 400 },
+);
+
+watchDebounced(
+    hslInput,
+    (value) => {
+        const tuple = parseHsl(value);
+        if (!tuple) {
+            return;
+        }
+        const { r, g, b } = hslToRgb(tuple[0], tuple[1], tuple[2]);
+        const next = rgbToHex(r, g, b);
+        if (next !== color.value) {
+            color.value = next;
+        }
+    },
+    { debounce: 180, maxWait: 400 },
+);
+
+function parseRgb(value: string): [number, number, number] | null {
+    const matches = value.match(/-?\d+(?:\.\d+)?/g);
+    if (!matches || matches.length < 3) {
+        return null;
+    }
+    const [r, g, b] = matches
+        .slice(0, 3)
+        .map((part) => Number(part))
+        .map((n) => Math.round(clamp(Number.isNaN(n) ? 0 : n, 0, 255)));
+    if ([r, g, b].some((n) => Number.isNaN(n))) {
+        return null;
+    }
+    return [r, g, b];
+}
+
+function parseHsl(value: string): [number, number, number] | null {
+    const matches = value.match(/-?\d+(?:\.\d+)?/g);
+    if (!matches || matches.length < 3) {
+        return null;
+    }
+    const [hRaw, sRaw, lRaw] = matches.slice(0, 3).map((part) => Number(part));
+    if ([hRaw, sRaw, lRaw].some((n) => Number.isNaN(n))) {
+        return null;
+    }
+    const h = ((hRaw % 360) + 360) % 360;
+    const s = clamp(sRaw, 0, 100);
+    const l = clamp(lRaw, 0, 100);
+    return [Math.round(h), Math.round(s), Math.round(l)];
+}
 
 /** Close the modal and emit the current color. */
 function closeWithCommit(): void {
@@ -46,11 +152,61 @@ function closeWithCommit(): void {
             class="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 backdrop-blur-[2px]"
             @click.self="closeWithCommit"
         >
-            <div class="bg-surface-low ring-surface-high rounded-xl p-4 shadow-xl ring-1">
-                <ColorWheel
-                    v-model="color"
-                    :size="size"
-                />
+            <div
+                class="bg-surface-low ring-surface-high w-full max-w-3xl space-y-6 rounded-xl p-6 shadow-xl ring-1"
+            >
+                <div class="flex flex-col gap-6 md:flex-row">
+                    <ColorWheel
+                        v-model="color"
+                        :size="size"
+                    />
+                    <div class="flex flex-1 flex-col gap-4">
+                        <div class="flex flex-col gap-2">
+                            <label class="text-fg-primary text-xs font-semibold uppercase"
+                                >Hex</label
+                            >
+                            <input
+                                v-model="hexInput"
+                                class="bg-surface text-fg-primary border-surface-high/40 focus:ring-accent rounded-md border px-3 py-2 text-sm focus:ring-2 focus:outline-none"
+                            />
+                        </div>
+                        <div class="flex flex-col gap-2">
+                            <label class="text-fg-primary text-xs font-semibold uppercase"
+                                >RGB</label
+                            >
+                            <input
+                                v-model="rgbInput"
+                                placeholder="255, 255, 255"
+                                class="bg-surface text-fg-primary border-surface-high/40 focus:ring-accent rounded-md border px-3 py-2 text-sm focus:ring-2 focus:outline-none"
+                            />
+                        </div>
+                        <div class="flex flex-col gap-2">
+                            <label class="text-fg-primary text-xs font-semibold uppercase"
+                                >HSL</label
+                            >
+                            <input
+                                v-model="hslInput"
+                                placeholder="0, 100, 50"
+                                class="bg-surface text-fg-primary border-surface-high/40 focus:ring-accent rounded-md border px-3 py-2 text-sm focus:ring-2 focus:outline-none"
+                            />
+                        </div>
+                        <div class="flex items-center gap-3">
+                            <span class="text-fg-secondary text-sm">Preview</span>
+                            <div
+                                class="ring-surface-high h-12 w-12 rounded-md ring-1"
+                                :style="{ backgroundColor: color }"
+                            />
+                        </div>
+                    </div>
+                </div>
+                <div class="flex justify-end gap-2">
+                    <button
+                        class="text-fg-secondary hover:text-fg-primary rounded-md px-4 py-2 text-sm transition-colors"
+                        @click="closeWithCommit"
+                    >
+                        Done
+                    </button>
+                </div>
             </div>
         </div>
     </Teleport>

--- a/slice-guard/frontend/src/modals/UserProfileModal.vue
+++ b/slice-guard/frontend/src/modals/UserProfileModal.vue
@@ -87,7 +87,7 @@ onUnmounted(() => {
                         </div>
                     </div>
                     <button
-                        class="text-fg-secondary hover:text-fg-primary focus-visible:outline-accent rounded-full p-2 transition-colors focus-visible:outline focus-visible:outline-2"
+                        class="text-fg-secondary hover:text-fg-primary focus-visible:outline-accent rounded-full p-2 transition-colors focus-visible:outline-2"
                         @click="close"
                     >
                         <XMarkIcon class="h-5 w-5" />

--- a/slice-guard/frontend/src/modals/UserProfileModal.vue
+++ b/slice-guard/frontend/src/modals/UserProfileModal.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { computed, onUnmounted, watch } from 'vue';
+import { useUiStore } from '../store/ui';
+import { useLabsStore } from '../store/labs';
+import UserAvatar from '../components/UserAvatar.vue';
+import { XMarkIcon } from '@heroicons/vue/24/outline';
+
+const ui = useUiStore();
+const labs = useLabsStore();
+
+const target = computed(() => ui.userProfile);
+const lab = computed(() => (target.value ? labs.getLab(target.value.labId) : null));
+const member = computed(() => {
+    if (!target.value) {
+        return null;
+    }
+    return labs.members.get(target.value.labId)?.get(target.value.userId) ?? null;
+});
+const user = computed(() => (target.value ? labs.getUser(target.value.userId) : null));
+const roles = computed(() => member.value?.roles ?? []);
+const joinedAt = computed(() => (member.value ? new Date(member.value.joined_at) : null));
+
+function close(): void {
+    ui.closeUserProfile();
+}
+
+function handleKey(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+        close();
+    }
+}
+
+watch(
+    target,
+    (val) => {
+        if (val) {
+            document.addEventListener('keydown', handleKey);
+            document.body.style.overflow = 'hidden';
+        } else {
+            document.removeEventListener('keydown', handleKey);
+            document.body.style.overflow = '';
+        }
+    },
+    { immediate: true },
+);
+
+onUnmounted(() => {
+    document.removeEventListener('keydown', handleKey);
+    document.body.style.overflow = '';
+});
+</script>
+
+<template>
+    <Teleport to="body">
+        <div
+            v-if="target"
+            class="fixed inset-0 z-[120] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+            @click.self="close"
+        >
+            <div
+                class="bg-surface-low ring-surface-high w-full max-w-xl space-y-6 rounded-2xl p-6 shadow-xl ring-1"
+            >
+                <div class="flex items-start justify-between gap-4">
+                    <div class="flex items-start gap-4">
+                        <UserAvatar
+                            v-if="user"
+                            :user="user"
+                            size="size-16"
+                        />
+                        <div
+                            v-else
+                            class="bg-surface-lowest h-16 w-16 rounded-full"
+                        />
+                        <div class="space-y-1">
+                            <h2 class="text-fg-primary text-xl font-semibold">
+                                {{ user?.name || user?.email || 'Unknown member' }}
+                            </h2>
+                            <p class="text-fg-secondary text-sm">
+                                {{ lab?.name || '—' }}
+                            </p>
+                            <p
+                                v-if="user?.email"
+                                class="text-fg-tertiary text-xs"
+                            >
+                                {{ user.email }}
+                            </p>
+                        </div>
+                    </div>
+                    <button
+                        class="text-fg-secondary hover:text-fg-primary focus-visible:outline-accent rounded-full p-2 transition-colors focus-visible:outline focus-visible:outline-2"
+                        @click="close"
+                    >
+                        <XMarkIcon class="h-5 w-5" />
+                    </button>
+                </div>
+                <div class="space-y-4">
+                    <div
+                        v-if="roles.length"
+                        class="flex flex-wrap gap-2"
+                    >
+                        <span
+                            v-for="role in roles"
+                            :key="role.id"
+                            class="bg-surface text-fg-primary border-surface-high/40 rounded-full border px-3 py-1 text-xs font-medium"
+                            :style="
+                                role.color ? { borderColor: role.color, color: role.color } : {}
+                            "
+                        >
+                            {{ role.name }}
+                        </span>
+                    </div>
+                    <p
+                        v-if="joinedAt"
+                        class="text-fg-secondary text-sm"
+                    >
+                        Joined {{ joinedAt.toLocaleDateString() }}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </Teleport>
+</template>

--- a/slice-guard/frontend/src/modals/lab_settings/LabSettings.vue
+++ b/slice-guard/frontend/src/modals/lab_settings/LabSettings.vue
@@ -18,14 +18,14 @@ const pages = {
         { name: 'General', component: defineAsyncComponent(() => import('./General.vue')), id: 1 },
         ...(hasLabPermission(perms, LabPermission.MANAGE_ROLES)
             ? [
-                {
-                    name: 'Roles',
-                    component: defineAsyncComponent(
-                        () => import('./roles/RoleSettingsLayout.vue'),
-                    ),
-                    id: 2,
-                },
-            ]
+                  {
+                      name: 'Roles',
+                      component: defineAsyncComponent(
+                          () => import('./roles/RoleSettingsLayout.vue'),
+                      ),
+                      id: 2,
+                  },
+              ]
             : []),
     ],
 };

--- a/slice-guard/frontend/src/modals/lab_settings/roles/RoleSettingsLayout.vue
+++ b/slice-guard/frontend/src/modals/lab_settings/roles/RoleSettingsLayout.vue
@@ -35,8 +35,8 @@ watch(
     { immediate: true },
 );
 
-const member = labs.members.get(labId)?.get(auth.user?.id ?? 0) ?? null;
-const topRank = member?.roles[0]?.rank ?? 0;
+const member = computed(() => labs.members.get(labId)?.get(auth.user?.id ?? 0) ?? null);
+const topRank = computed(() => member.value?.roles[0]?.rank ?? 0);
 
 const selectedRole: ComputedRef<LabRole | null> = computed(
     () => roleList.value.find((r) => r.id === selectedId.value) || null,
@@ -47,26 +47,68 @@ const listEl = useTemplateRef<HTMLElement>('listEl');
 // The roles that the user cannot edit (below them) will not be included in
 // useSortable and will be marked as disabled. The others will be draggable.
 const editableRoles = computed(() => {
-    if (!member) {
+    if (!member.value) {
         return [];
     }
-    return roleList.value.filter((r) => r.rank < topRank);
+    return roleList.value.filter((r) => r.rank < topRank.value);
 });
 
 const nonEditableRoles = computed(() => {
-    if (!member) {
+    if (!member.value) {
         return [];
     }
-    return roleList.value.filter((r) => r.rank >= topRank);
+    return roleList.value.filter((r) => r.rank >= topRank.value);
 });
 
 useSortable(listEl, editableRoles, {
     onUpdate: async () => {
-        // Merge updated draggable roles with non-editable roles
         roleList.value = [...nonEditableRoles.value, ...editableRoles.value];
-        // ! TODO: API call for update
+        await persistRoleOrder();
     },
 });
+
+async function persistRoleOrder(): Promise<void> {
+    if (!member.value) {
+        return;
+    }
+
+    const editable = editableRoles.value;
+    if (editable.length === 0) {
+        return;
+    }
+
+    let nextRank = topRank.value - 1;
+    const updates: { role: LabRole; newRank: number }[] = [];
+    for (const role of editable) {
+        const newRank = nextRank;
+        nextRank -= 1;
+        if (role.rank !== newRank) {
+            updates.push({ role, newRank });
+        }
+        role.rank = newRank;
+    }
+
+    roleList.value = [...nonEditableRoles.value, ...editable]
+        .slice()
+        .sort((a, b) => b.rank - a.rank || a.id - b.id);
+
+    for (const { role, newRank } of updates) {
+        const res = await apiFetch(`/labs/${labId}/roles/${role.id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                permissions: Number(role.permissions),
+                rank: newRank,
+            }),
+        });
+        if (!res.ok) {
+            console.error('[labs] failed to persist role rank', res);
+            continue;
+        }
+        const updated = (await res.json()) as LabRole;
+        labs.updateRole(labId, updated);
+    }
+}
 
 /**
  * Create a new role at a rank the current user can manage and select it.
@@ -79,12 +121,13 @@ async function createRole() {
             name: 'new role',
             color: '#888888',
             permissions: 0,
+            rank: topRank.value > 0 ? topRank.value - 1 : 1,
         }),
     });
 
     if (res.ok) {
         const role: LabRole = await res.json();
-        labs.roles.get(labId)?.set(role.id, role);
+        labs.addRole(labId, role);
         roleList.value.push(role);
         roleList.value.sort((a, b) => b.rank - a.rank);
         selectedId.value = role.id;

--- a/slice-guard/frontend/src/store/labs.ts
+++ b/slice-guard/frontend/src/store/labs.ts
@@ -1,11 +1,18 @@
 import { defineStore } from 'pinia';
 import type { RequestTag } from '@shared/db/request';
 import type { LabState, PrintRequestEvent, MemberEvent } from '@shared/payloads/ws';
-import type { LabInvite, LabRole, Lab, LabMember } from '@shared/db/lab';
+import {
+    LabPermission,
+    type LabInvite,
+    type LabRole,
+    type Lab,
+    type LabMember,
+} from '@shared/db/lab';
 import type { Channel } from '@shared/db/channel';
 import type { User } from '@shared/db/user';
 import type { Message } from '@shared/db/message';
 import { useAuthStore } from './auth';
+import { computeMemberPermissions } from '../utils/permissions';
 
 const DEV = import.meta.env.DEV;
 
@@ -89,11 +96,50 @@ export const useLabsStore = defineStore('labs', {
 
         /** Get permissions for a lab */
         getLabPermissions: (state) => (labId: LabId) => {
+            const auth = useAuthStore();
+            const userId = auth.user?.id;
+            if (!userId) {
+                return 0;
+            }
+
+            const lab = state.labs.get(labId) || null;
+            if (lab && lab.owner_id === userId) {
+                return LabPermission.ALL;
+            }
+
+            const member = state.members.get(labId)?.get(userId) ?? null;
+            const computed = computeMemberPermissions(member);
+            if (computed !== null) {
+                return computed;
+            }
+
             return state.permissions.get(labId) || 0;
         },
     },
 
     actions: {
+        recomputePermissions(labId: LabId) {
+            const auth = useAuthStore();
+            const userId = auth.user?.id;
+            if (!userId) {
+                this.permissions.delete(labId);
+                return;
+            }
+
+            const lab = this.labs.get(labId) || null;
+            if (lab && lab.owner_id === userId) {
+                this.permissions.set(labId, LabPermission.ALL);
+                return;
+            }
+
+            const member = this.members.get(labId)?.get(userId) ?? null;
+            const computed = computeMemberPermissions(member);
+            if (computed !== null) {
+                this.permissions.set(labId, computed);
+            } else {
+                this.permissions.delete(labId);
+            }
+        },
         /** Initialize store with labs from server. */
         setInitial(labStates: LabState[]) {
             if (DEV) {
@@ -201,6 +247,9 @@ export const useLabsStore = defineStore('labs', {
 
             // Store permissions
             this.permissions.set(labId, labState.permissions || 0);
+
+            // Ensure cached permissions match current member state
+            this.recomputePermissions(labId);
         },
 
         /** Update basic lab info. */
@@ -394,6 +443,7 @@ export const useLabsStore = defineStore('labs', {
             if (members) {
                 members.set(event.member.user_id, event.member);
             }
+            this.recomputePermissions(labId);
         },
         /** Remove member by user id. */
         removeMember(labId: LabId, userId: UserId) {
@@ -405,6 +455,7 @@ export const useLabsStore = defineStore('labs', {
             if (members) {
                 members.delete(userId);
             }
+            this.recomputePermissions(labId);
         },
         /** Handle member leave events. */
         handleMemberLeft(labId: LabId, userId: UserId) {
@@ -415,6 +466,8 @@ export const useLabsStore = defineStore('labs', {
                     console.debug('[labs] removeLab', labId);
                 }
                 this.removeLab(labId);
+            } else {
+                this.recomputePermissions(labId);
             }
         },
         /** Add an invite to the lab. */
@@ -460,6 +513,17 @@ export const useLabsStore = defineStore('labs', {
             if (roles) {
                 roles.set(role.id, role);
             }
+            const members = this.members.get(labId);
+            if (members) {
+                for (const member of members.values()) {
+                    const idx = member.roles.findIndex((r) => r.id === role.id);
+                    if (idx !== -1) {
+                        member.roles[idx] = role;
+                        member.roles.sort((a, b) => b.rank - a.rank || a.id - b.id);
+                    }
+                }
+            }
+            this.recomputePermissions(labId);
         },
         /** Update role fields. */
         updateRole(labId: LabId, role: LabRole) {
@@ -482,6 +546,15 @@ export const useLabsStore = defineStore('labs', {
             if (roles) {
                 roles.delete(roleId);
             }
+            const members = this.members.get(labId);
+            if (members) {
+                for (const member of members.values()) {
+                    member.roles = member.roles
+                        .filter((r) => r.id !== roleId)
+                        .sort((a, b) => b.rank - a.rank || a.id - b.id);
+                }
+            }
+            this.recomputePermissions(labId);
         },
         /**
          * Add a user's public profile information

--- a/slice-guard/frontend/src/store/ui.ts
+++ b/slice-guard/frontend/src/store/ui.ts
@@ -1,0 +1,20 @@
+import { defineStore } from 'pinia';
+
+export interface UserProfileTarget {
+    labId: number;
+    userId: number;
+}
+
+export const useUiStore = defineStore('ui', {
+    state: () => ({
+        userProfile: null as UserProfileTarget | null,
+    }),
+    actions: {
+        openUserProfile(target: UserProfileTarget) {
+            this.userProfile = target;
+        },
+        closeUserProfile() {
+            this.userProfile = null;
+        },
+    },
+});

--- a/slice-guard/frontend/src/utils/color.ts
+++ b/slice-guard/frontend/src/utils/color.ts
@@ -19,6 +19,13 @@ export interface Hsv {
     v: number;
 }
 
+/** HSL color components. `h` in degrees [0,360), `s` and `l` in [0,100]. */
+export interface Hsl {
+    h: number;
+    s: number;
+    l: number;
+}
+
 /** Clamp a number between `min` and `max`. */
 export function clamp(n: number, min = 0, max = 1): number {
     return Math.min(max, Math.max(min, n));
@@ -133,5 +140,74 @@ export function hsvToRgb(h: number, s: number, v: number): Rgb {
             b = q;
             break;
     }
+    return { r: Math.round(r * 255), g: Math.round(g * 255), b: Math.round(b * 255) };
+}
+
+/** Convert RGB components (0-255) to HSL. */
+export function rgbToHsl(r: number, g: number, b: number): Hsl {
+    r /= 255;
+    g /= 255;
+    b /= 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+
+    if (max === min) {
+        return { h: 0, s: 0, l: l * 100 };
+    }
+
+    const d = max - min;
+    const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    let h = 0;
+    switch (max) {
+        case r:
+            h = (g - b) / d + (g < b ? 6 : 0);
+            break;
+        case g:
+            h = (b - r) / d + 2;
+            break;
+        default:
+            h = (r - g) / d + 4;
+            break;
+    }
+    h /= 6;
+    return { h: h * 360, s: s * 100, l: l * 100 };
+}
+
+/** Convert HSL components to RGB. */
+export function hslToRgb(h: number, s: number, l: number): Rgb {
+    h = ((h % 360) + 360) % 360;
+    s = clamp(s / 100);
+    l = clamp(l / 100);
+
+    if (s === 0) {
+        const v = Math.round(l * 255);
+        return { r: v, g: v, b: v };
+    }
+
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    const hk = h / 360;
+    const channel = (t: number) => {
+        if (t < 0) {
+            t += 1;
+        }
+        if (t > 1) {
+            t -= 1;
+        }
+        if (t < 1 / 6) {
+            return p + (q - p) * 6 * t;
+        }
+        if (t < 1 / 2) {
+            return q;
+        }
+        if (t < 2 / 3) {
+            return p + (q - p) * (2 / 3 - t) * 6;
+        }
+        return p;
+    };
+    const r = channel(hk + 1 / 3);
+    const g = channel(hk);
+    const b = channel(hk - 1 / 3);
     return { r: Math.round(r * 255), g: Math.round(g * 255), b: Math.round(b * 255) };
 }

--- a/slice-guard/frontend/src/utils/permissions.ts
+++ b/slice-guard/frontend/src/utils/permissions.ts
@@ -11,7 +11,14 @@ export function computeMemberPermissions(member: LabMember | null): number | nul
     if (!member) {
         return null;
     }
-    // Roles are expected to be ordered by rank DESC from backend.
-    const top = member.roles[0];
-    return top ? Number(top.permissions) : null;
+    const roles = [...member.roles].sort((a, b) => b.rank - a.rank || a.id - b.id);
+    if (roles.length === 0) {
+        return null;
+    }
+
+    let mask = Number(roles[0].permissions);
+    for (let i = 1; i < roles.length; i += 1) {
+        mask |= Number(roles[i].permissions);
+    }
+    return mask;
 }

--- a/slice-guard/frontend/src/views/lab/LabUserList.vue
+++ b/slice-guard/frontend/src/views/lab/LabUserList.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { ref, computed, type ComputedRef } from 'vue';
+import { ref, computed, type ComputedRef, watch } from 'vue';
 import type { Lab, LabMember } from '@shared/db/lab';
 import { useLabsStore } from '../../store/labs';
 import SearchBar from '../../components/SearchBar.vue';
 import UserAvatar from '../../components/UserAvatar.vue';
 import { type User } from '@shared/db/user';
+import { useUiStore } from '../../store/ui';
+import { breakpointsTailwind, useBreakpoints } from '@vueuse/core';
 
 type RoleName = string;
 
@@ -15,7 +17,34 @@ const props = defineProps<{
 }>();
 
 const labs = useLabsStore();
+const ui = useUiStore();
 const search = ref('');
+
+const breakpoints = useBreakpoints(breakpointsTailwind);
+const isCompact = breakpoints.smaller('md');
+const collapsed = ref(false);
+
+watch(
+    isCompact,
+    (small) => {
+        collapsed.value = small;
+    },
+    { immediate: true },
+);
+
+function toggleCollapsed(): void {
+    if (!isCompact.value) {
+        return;
+    }
+    collapsed.value = !collapsed.value;
+}
+
+function openProfile(userId: number): void {
+    if (!props.lab) {
+        return;
+    }
+    ui.openUserProfile({ labId: props.lab.id, userId });
+}
 
 const members = computed(() => {
     return (props.lab && labs.getLabMembers(props.lab.id)) || [];
@@ -91,50 +120,68 @@ const sortedFilteredMembers = computed(() => {
 
 <template>
     <div class="flex flex-col gap-4">
-        <!-- Search bar to filter users -->
-        <SearchBar
-            v-model="search"
-            placeholder="Search users..."
-        />
-        <!-- Display the list of users categorized by role -->
+        <div class="flex items-center justify-between md:hidden">
+            <h2 class="text-fg-primary text-sm font-semibold uppercase">Members</h2>
+            <button
+                type="button"
+                class="text-fg-secondary hover:text-fg-primary rounded-md px-2 py-1 text-xs font-medium transition-colors"
+                @click="toggleCollapsed"
+            >
+                {{ collapsed ? 'Show' : 'Hide' }}
+            </button>
+        </div>
+
         <div
-            v-for="entry in sortedFilteredMembers"
-            :key="entry.category"
-            class="flex flex-col gap-2"
+            v-if="!collapsed"
+            class="flex flex-col gap-4"
         >
-            <!-- Category header -->
-            <h3 class="text-fg-primary px-2 text-xs font-medium tracking-wide uppercase">
-                {{ entry.category }}
-            </h3>
+            <!-- Search bar to filter users -->
+            <SearchBar
+                v-model="search"
+                placeholder="Search users..."
+            />
+            <!-- Display the list of users categorized by role -->
+            <div
+                v-for="entry in sortedFilteredMembers"
+                :key="entry.category"
+                class="flex flex-col gap-2"
+            >
+                <!-- Category header -->
+                <h3 class="text-fg-primary px-2 text-xs font-medium tracking-wide uppercase">
+                    {{ entry.category }}
+                </h3>
 
-            <!-- Users in this category -->
-            <ul class="space-y-1">
-                <li
-                    v-for="u in entry.users"
-                    :key="u.member.user_id"
-                >
-                    <div
-                        class="text-fg-secondary hover:text-fg-primary hover:bg-surface flex items-center justify-start gap-3 rounded-xl p-2 transition-all duration-200 hover:shadow-md"
+                <!-- Users in this category -->
+                <ul class="space-y-1">
+                    <li
+                        v-for="u in entry.users"
+                        :key="u.member.user_id"
                     >
-                        <UserAvatar
-                            v-if="u.user"
-                            :user="u.user"
-                            size="size-7"
-                        />
-                        <div
-                            v-else
-                            class="h-7 w-7 flex-none rounded-full bg-gray-700"
-                        ></div>
+                        <button
+                            type="button"
+                            class="text-fg-secondary hover:text-fg-primary hover:bg-surface flex w-full items-center justify-start gap-3 rounded-xl p-2 text-left transition-all duration-200 hover:shadow-md"
+                            @click="openProfile(u.member.user_id)"
+                        >
+                            <UserAvatar
+                                v-if="u.user"
+                                :user="u.user"
+                                size="size-7"
+                            />
+                            <div
+                                v-else
+                                class="h-7 w-7 flex-none rounded-full bg-gray-700"
+                            ></div>
 
-                        <span class="truncate text-sm">
-                            {{ u.user?.name || u.user?.email || u.member.user_id }}
-                        </span>
-                    </div>
-                </li>
-            </ul>
+                            <span class="truncate text-sm">
+                                {{ u.user?.name || u.user?.email || u.member.user_id }}
+                            </span>
+                        </button>
+                    </li>
+                </ul>
 
-            <!-- Divider line -->
-            <hr class="border-surface-high my-2" />
+                <!-- Divider line -->
+                <hr class="border-surface-high my-2" />
+            </div>
         </div>
     </div>
 </template>

--- a/slice-guard/frontend/src/views/lab/channels/ChannelView.vue
+++ b/slice-guard/frontend/src/views/lab/channels/ChannelView.vue
@@ -179,6 +179,7 @@ onMounted(() => {
                 :key="m.id"
                 :message="m"
                 :author="labs.getUser(m.user_id)!"
+                :lab-id="channel?.lab_id ?? null"
             />
 
             <!-- Empty state -->


### PR DESCRIPTION
## Summary
- aggregate lab role permissions on the backend and update tests to cover the new behavior
- track websocket connections per user so lab creation broadcasts only reach the owner
- recompute lab permissions client-side, update role management ordering, and add a responsive user profile modal with supporting store updates
- expand the color picker with synchronized Hex/RGB/HSL inputs and document the refactor

## Testing
- bun run lint *(fails: repository contains pre-existing lint errors in backend files)*
- bun run format:check
- bun run test *(backend suite passes; frontend workspace lacks a test script)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a4fe6adc8320bd7da96406839ca5